### PR TITLE
feat: add 11 new providers and enhance 7 existing detections

### DIFF
--- a/.cursor/rules/sync-antibot-detector.mdc
+++ b/.cursor/rules/sync-antibot-detector.mdc
@@ -1,0 +1,56 @@
+---
+description: Sync new detection rules from scrapfly/Antibot-Detector into is-antibot
+alwaysApply: false
+---
+
+# Sync Antibot-Detector
+
+Periodically port new detection signals from the upstream [scrapfly/Antibot-Detector](https://github.com/scrapfly/Antibot-Detector) browser extension into this Node.js library.
+
+## Prerequisites
+
+Clone or update the upstream repo into `/tmp/Antibot-Detector`:
+
+```bash
+git clone https://github.com/scrapfly/Antibot-Detector /tmp/Antibot-Detector
+```
+
+## How to find what changed
+
+1. Read the last `is-antibot` commit that references `Antibot-Detector@<sha>` to get the baseline SHA.
+2. In `/tmp/Antibot-Detector`, run `git log --oneline <baseline-sha>..HEAD -- detectors/` to see what detector files changed.
+3. Read every changed/new JSON file under `detectors/antibot/` and `detectors/captcha/`.
+4. Compare against the current checks in `src/index.js` to identify gaps.
+
+## What can be ported
+
+This library only has access to HTTP responses (headers, body, URL, set-cookie). Only port signals from these JSON fields:
+
+| Antibot-Detector field | is-antibot mechanism |
+|---|---|
+| `detection.header` | `getHeader(headers, name)` |
+| `detection.content` | `testPattern(body, text)` |
+| `detection.url` | `testPattern(url, text)` or `testPattern(url, regex, true)` |
+| `detection.cookie` | `testSetCookie(headers, 'name=')` |
+
+Skip `detection.window`, `detection.dom`, `detection.payload`, and any fingerprint detectors — they require a browser runtime.
+
+## Coding conventions
+
+- Provider keys are lowercase, hyphen-separated: `friendly-captcha`, `aws-waf`, `qcloud-captcha`.
+- Each check is a standalone `if` returning `createResult(true, 'provider')`.
+- Every check gets a comment with a short description and a Reference URL when available.
+- No section-separator comments (e.g. `// --- Provider ---`) in `src/index.js`.
+- Tests go in `test/index.js`, one `test('provider (signal)', ...)` per signal type.
+- No section-separator comments in `test/index.js` either.
+- Run `npm test` (includes lint + ava + c8 coverage) and ensure all tests pass.
+
+## Commit message format
+
+```
+feat: add N new providers and enhance M existing detections
+
+Based on scrapfly/Antibot-Detector@<full-sha-of-latest-upstream-commit>
+```
+
+This SHA reference lets the next sync know where to resume.

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,11 @@ module.exports = ({ headers = {}, body = '', url = '' } = {}) => {
     return createResult(true, 'cloudflare')
   }
 
+  // Cloudflare: cf_clearance cookie indicates Cloudflare challenge flow
+  if (testSetCookie(headers, 'cf_clearance=')) {
+    return createResult(true, 'cloudflare')
+  }
+
   // Vercel: Check for x-vercel-mitigated header with 'challenge' value
   // Solver reference: https://github.com/glizzykingdreko/Vercel-Attack-Mode-Solver
   if (getHeader(headers, 'x-vercel-mitigated') === 'challenge') {
@@ -56,17 +61,30 @@ module.exports = ({ headers = {}, body = '', url = '' } = {}) => {
     return createResult(true, 'akamai')
   }
 
+  // Akamai: _abck bot manager tracking cookie
+  if (testSetCookie(headers, '_abck=')) {
+    return createResult(true, 'akamai')
+  }
+
+  // Akamai: Bot Manager API namespace (bmak) in body
+  if (body && testPattern(body, 'bmak.')) {
+    return createResult(true, 'akamai')
+  }
+
   // DataDome: Check for x-dd-b header with values '1' (soft challenge) or '2' (hard challenge/CAPTCHA)
   // Official docs: https://docs.datadome.co/reference/validate-request
-  // 1: Soft challenge / JS redirect / interstitial
-  // 2: Hard challenge / HTML redirect / CAPTCHA
   if (['1', '2'].includes(getHeader(headers, 'x-dd-b'))) {
     return createResult(true, 'datadome')
   }
 
-  // DataDome: Check for x-datadome header presence
+  // DataDome: Check for x-datadome or x-datadome-cid header presence
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/datadome.json
-  if (getHeader(headers, 'x-datadome')) {
+  if (getHeader(headers, 'x-datadome') || getHeader(headers, 'x-datadome-cid')) {
+    return createResult(true, 'datadome')
+  }
+
+  // DataDome: datadome tracking cookie
+  if (testSetCookie(headers, 'datadome=')) {
     return createResult(true, 'datadome')
   }
 
@@ -76,9 +94,19 @@ module.exports = ({ headers = {}, body = '', url = '' } = {}) => {
     return createResult(true, 'perimeterx')
   }
 
-  // PerimeterX: Check for window._pxAppId in body (JavaScript initialization)
+  // PerimeterX: Check for window._pxAppId, pxInit, or _pxAction in body
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/perimeterx.json#L130-L137
-  if (body && testPattern(body, 'window._pxAppId')) {
+  if (
+    body &&
+    (testPattern(body, 'window._pxAppId') ||
+      testPattern(body, 'pxInit') ||
+      testPattern(body, '_pxAction'))
+  ) {
+    return createResult(true, 'perimeterx')
+  }
+
+  // PerimeterX: _px3 or _pxhd cookies
+  if (testSetCookie(headers, '_px3=') || testSetCookie(headers, '_pxhd=')) {
     return createResult(true, 'perimeterx')
   }
 
@@ -134,12 +162,95 @@ module.exports = ({ headers = {}, body = '', url = '' } = {}) => {
     return createResult(true, 'imperva')
   }
 
-  // reCAPTCHA: Check for recaptcha/api or google.com/recaptcha in URL
+  // Imperva/Incapsula: incap_ses_, visid_incap_, or reese84 cookies
+  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/incapsula.json
+  if (
+    testSetCookie(headers, 'incap_ses_') ||
+    testSetCookie(headers, 'visid_incap_') ||
+    testSetCookie(headers, 'reese84=')
+  ) {
+    return createResult(true, 'imperva')
+  }
+
+  // Reblaze: rbzid or rbzsessionid cookies
+  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/reblaze.json
+  if (
+    testSetCookie(headers, 'rbzid=') ||
+    testSetCookie(headers, 'rbzsessionid=')
+  ) {
+    return createResult(true, 'reblaze')
+  }
+
+  // Reblaze: Check for 'reblaze' text in response body
+  if (body && testPattern(body, 'reblaze')) {
+    return createResult(true, 'reblaze')
+  }
+
+  // Cheq: Check for CheqSdk or cheqzone.com in body
+  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/cheq.json
+  if (
+    body &&
+    (testPattern(body, 'CheqSdk') || testPattern(body, 'cheqzone.com'))
+  ) {
+    return createResult(true, 'cheq')
+  }
+
+  // Cheq: Check for cheqzone.com or cheq.ai in URL
+  if (
+    url &&
+    (testPattern(url, 'cheqzone\\.com', true) ||
+      testPattern(url, 'cheq\\.ai', true))
+  ) {
+    return createResult(true, 'cheq')
+  }
+
+  // Sucuri: Check for 'sucuri' text in response body
+  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/sucuri.json
+  if (body && testPattern(body, 'sucuri')) {
+    return createResult(true, 'sucuri')
+  }
+
+  // ThreatMetrix: Check for 'ThreatMetrix' in body
+  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/threatmetrix.json
+  if (body && testPattern(body, 'ThreatMetrix')) {
+    return createResult(true, 'threatmetrix')
+  }
+
+  // ThreatMetrix: Check for fp/check.js fingerprint endpoint in URL
+  if (url && testPattern(url, 'fp/check.js')) {
+    return createResult(true, 'threatmetrix')
+  }
+
+  // Meetrics: Check for 'meetrics' text in response body
+  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/meetrics.json
+  if (body && testPattern(body, 'meetrics')) {
+    return createResult(true, 'meetrics')
+  }
+
+  // Meetrics: Check for meetrics.com in URL
+  if (url && testPattern(url, 'meetrics\\.com', true)) {
+    return createResult(true, 'meetrics')
+  }
+
+  // Ocule: Check for ocule.co.uk in body
+  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/ocule.json
+  if (body && testPattern(body, 'ocule.co.uk')) {
+    return createResult(true, 'ocule')
+  }
+
+  // Ocule: Check for ocule.co.uk in URL
+  if (url && testPattern(url, 'ocule\\.co\\.uk', true)) {
+    return createResult(true, 'ocule')
+  }
+
+  // reCAPTCHA: Check for recaptcha/api, google.com/recaptcha, gstatic.com/recaptcha, or recaptcha.net in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/recaptcha.json#L13-L48
   if (
     url &&
     (testPattern(url, 'recaptcha/api') ||
-      testPattern(url, 'google\\.com/recaptcha', true))
+      testPattern(url, 'google\\.com/recaptcha', true) ||
+      testPattern(url, 'gstatic.com/recaptcha') ||
+      testPattern(url, 'recaptcha.net'))
   ) {
     return createResult(true, 'recaptcha')
   }
@@ -212,7 +323,6 @@ module.exports = ({ headers = {}, body = '', url = '' } = {}) => {
   }
 
   // Cloudflare Turnstile: Check for challenges.cloudflare.com/turnstile in URL
-  // Turnstile is Cloudflare's CAPTCHA alternative with privacy focus
   if (
     url &&
     testPattern(url, 'challenges\\.cloudflare\\.com/turnstile', true)
@@ -220,14 +330,69 @@ module.exports = ({ headers = {}, body = '', url = '' } = {}) => {
     return createResult(true, 'cloudflare-turnstile')
   }
 
-  // Cloudflare Turnstile: Check for cf-turnstile class in body (primary indicator)
+  // Cloudflare Turnstile: Check for cf-turnstile class in body
   if (body && testPattern(body, 'cf-turnstile')) {
     return createResult(true, 'cloudflare-turnstile')
   }
 
-  // Cloudflare Turnstile: Check for turnstile text in body (secondary indicator)
+  // Cloudflare Turnstile: Check for turnstile text in body
   if (body && testPattern(body, 'turnstile')) {
     return createResult(true, 'cloudflare-turnstile')
+  }
+
+  // Friendly Captcha: Check for friendlycaptcha.com in URL
+  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/friendlycaptcha.json
+  if (url && testPattern(url, 'friendlycaptcha\\.com', true)) {
+    return createResult(true, 'friendly-captcha')
+  }
+
+  // Friendly Captcha: Check for frc-captcha container or friendlyChallenge object in body
+  if (
+    body &&
+    (testPattern(body, 'frc-captcha') ||
+      testPattern(body, 'friendlyChallenge'))
+  ) {
+    return createResult(true, 'friendly-captcha')
+  }
+
+  // Captcha.eu: Check for captcha.eu in URL
+  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/captchaeu.json
+  if (url && testPattern(url, 'captcha\\.eu', true)) {
+    return createResult(true, 'captcha-eu')
+  }
+
+  // Captcha.eu: Check for CaptchaEU or captchaeu in body
+  if (
+    body &&
+    (testPattern(body, 'CaptchaEU') || testPattern(body, 'captchaeu'))
+  ) {
+    return createResult(true, 'captcha-eu')
+  }
+
+  // QCloud Captcha (Tencent): Check for turing.captcha.qcloud.com in URL
+  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/qcloud.json
+  if (url && testPattern(url, 'turing\\.captcha\\.qcloud\\.com', true)) {
+    return createResult(true, 'qcloud-captcha')
+  }
+
+  // QCloud Captcha: Check for TencentCaptcha or turing.captcha in body
+  if (
+    body &&
+    (testPattern(body, 'TencentCaptcha') ||
+      testPattern(body, 'turing.captcha'))
+  ) {
+    return createResult(true, 'qcloud-captcha')
+  }
+
+  // AliExpress CAPTCHA: Check for punish?x5secdata in URL
+  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/aliexpress.json
+  if (url && testPattern(url, 'punish\\?x5secdata', true)) {
+    return createResult(true, 'aliexpress-captcha')
+  }
+
+  // AliExpress CAPTCHA: Check for x5secdata in body
+  if (body && testPattern(body, 'x5secdata')) {
+    return createResult(true, 'aliexpress-captcha')
   }
 
   // LinkedIn: trkCode=bf cookie ("bot filter") is set when LinkedIn blocks a request
@@ -236,7 +401,6 @@ module.exports = ({ headers = {}, body = '', url = '' } = {}) => {
   }
 
   // AWS WAF: Check for x-amzn-waf-action or x-amzn-requestid headers
-  // These headers are set by AWS WAF when bot control rules are triggered
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/aws-waf.json
   if (
     getHeader(headers, 'x-amzn-waf-action') ||
@@ -245,9 +409,13 @@ module.exports = ({ headers = {}, body = '', url = '' } = {}) => {
     return createResult(true, 'aws-waf')
   }
 
-  // AWS WAF: Check for aws-waf text in body (challenge page indicator)
-  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/aws-waf.json#L47-L73
-  if (body && testPattern(body, 'aws-waf')) {
+  // AWS WAF: Check for aws-waf or awswaf text in body
+  if (body && (testPattern(body, 'aws-waf') || testPattern(body, 'awswaf'))) {
+    return createResult(true, 'aws-waf')
+  }
+
+  // AWS WAF: aws-waf-token cookie
+  if (testSetCookie(headers, 'aws-waf-token=')) {
     return createResult(true, 'aws-waf')
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,8 +4,15 @@ const test = require('ava')
 
 const isAntibot = require('../src')
 
-test('cloudflare', t => {
+test('cloudflare (cf-mitigated header)', t => {
   const headers = { 'cf-mitigated': 'challenge' }
+  const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'cloudflare')
+})
+
+test('cloudflare (cf_clearance set-cookie)', t => {
+  const headers = { 'set-cookie': 'cf_clearance=abc123; path=/' }
   const result = isAntibot({ headers })
   t.is(result.detected, true)
   t.is(result.provider, 'cloudflare')
@@ -18,16 +25,30 @@ test('vercel', t => {
   t.is(result.provider, 'vercel')
 })
 
-test('akamai', t => {
+test('akamai (akamai-cache-status error)', t => {
   const headers = { 'akamai-cache-status': 'Error from child' }
   const result = isAntibot({ headers })
   t.is(result.detected, true)
   t.is(result.provider, 'akamai')
 })
 
-test('akamai (with header)', t => {
+test('akamai (akamai-grn header)', t => {
   const headers = { 'akamai-grn': 'test123' }
   const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'akamai')
+})
+
+test('akamai (_abck set-cookie)', t => {
+  const headers = { 'set-cookie': '_abck=abc123~0~; path=/' }
+  const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'akamai')
+})
+
+test('akamai (bmak in body)', t => {
+  const body = '<script>bmak.sensor_data = "test";</script>'
+  const result = isAntibot({ body })
   t.is(result.detected, true)
   t.is(result.provider, 'akamai')
 })
@@ -39,7 +60,7 @@ test('akamai (no antibot)', t => {
   t.is(result.provider, null)
 })
 
-test('datadome', t => {
+test('datadome (x-dd-b header)', t => {
   for (const value of ['1', '2']) {
     const headers = { 'x-dd-b': value }
     const result = isAntibot({ headers })
@@ -48,8 +69,22 @@ test('datadome', t => {
   }
 })
 
-test('datadome (with header)', t => {
+test('datadome (x-datadome header)', t => {
   const headers = { 'x-datadome': 'test' }
+  const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'datadome')
+})
+
+test('datadome (x-datadome-cid header)', t => {
+  const headers = { 'x-datadome-cid': 'abc123' }
+  const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'datadome')
+})
+
+test('datadome (set-cookie)', t => {
+  const headers = { 'set-cookie': 'datadome=abc123; path=/' }
   const result = isAntibot({ headers })
   t.is(result.detected, true)
   t.is(result.provider, 'datadome')
@@ -62,9 +97,37 @@ test('perimeterx (header)', t => {
   t.is(result.provider, 'perimeterx')
 })
 
-test('perimeterx (body)', t => {
+test('perimeterx (body window._pxAppId)', t => {
   const body = '<script>window._pxAppId = "PX123";</script>'
   const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'perimeterx')
+})
+
+test('perimeterx (body pxInit)', t => {
+  const body = '<script>pxInit();</script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'perimeterx')
+})
+
+test('perimeterx (body _pxAction)', t => {
+  const body = '<script>var _pxAction = "c";</script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'perimeterx')
+})
+
+test('perimeterx (_px3 set-cookie)', t => {
+  const headers = { 'set-cookie': '_px3=abc123; path=/' }
+  const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'perimeterx')
+})
+
+test('perimeterx (_pxhd set-cookie)', t => {
+  const headers = { 'set-cookie': '_pxhd=abc123; path=/' }
+  const result = isAntibot({ headers })
   t.is(result.detected, true)
   t.is(result.provider, 'perimeterx')
 })
@@ -118,6 +181,125 @@ test('imperva (body with imperva)', t => {
   t.is(result.provider, 'imperva')
 })
 
+test('imperva (incap_ses_ set-cookie)', t => {
+  const headers = { 'set-cookie': 'incap_ses_123=abc; path=/' }
+  const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'imperva')
+})
+
+test('imperva (visid_incap_ set-cookie)', t => {
+  const headers = { 'set-cookie': 'visid_incap_456=xyz; path=/' }
+  const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'imperva')
+})
+
+test('imperva (reese84 set-cookie)', t => {
+  const headers = { 'set-cookie': 'reese84=abc123; path=/' }
+  const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'imperva')
+})
+
+test('reblaze (rbzid set-cookie)', t => {
+  const headers = { 'set-cookie': 'rbzid=abc123; path=/' }
+  const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'reblaze')
+})
+
+test('reblaze (rbzsessionid set-cookie)', t => {
+  const headers = { 'set-cookie': 'rbzsessionid=xyz; path=/' }
+  const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'reblaze')
+})
+
+test('reblaze (body)', t => {
+  const body = '<p>Protected by Reblaze</p>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'reblaze')
+})
+
+test('cheq (body CheqSdk)', t => {
+  const body = '<script>CheqSdk.init();</script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'cheq')
+})
+
+test('cheq (body cheqzone.com)', t => {
+  const body = '<script src="https://ob.cheqzone.com/script.js"></script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'cheq')
+})
+
+test('cheq (url cheqzone.com)', t => {
+  const url = 'https://ob.cheqzone.com/script.js'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'cheq')
+})
+
+test('cheq (url cheq.ai)', t => {
+  const url = 'https://cheq.ai/api/verify'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'cheq')
+})
+
+test('sucuri (body)', t => {
+  const body = '<p>Sucuri Website Firewall - Access Denied</p>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'sucuri')
+})
+
+test('threatmetrix (body)', t => {
+  const body = '<script>ThreatMetrix.init();</script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'threatmetrix')
+})
+
+test('threatmetrix (url fp/check.js)', t => {
+  const url = 'https://example.com/fp/check.js?org_id=abc'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'threatmetrix')
+})
+
+test('meetrics (body)', t => {
+  const body = '<script>meetricsGlobal.init();</script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'meetrics')
+})
+
+test('meetrics (url)', t => {
+  const url = 'https://s418.mxcdn.net/bb-mx/serve/meetrics.com/script'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'meetrics')
+})
+
+test('ocule (body)', t => {
+  const body = '<script src="https://proxy.ocule.co.uk/script.js"></script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'ocule')
+})
+
+test('ocule (url)', t => {
+  const url = 'https://proxy.ocule.co.uk/script.js'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'ocule')
+})
+
 test('recaptcha (url with recaptcha/api)', t => {
   const url = 'https://www.google.com/recaptcha/api.js'
   const result = isAntibot({ url })
@@ -132,8 +314,29 @@ test('recaptcha (url with google.com/recaptcha)', t => {
   t.is(result.provider, 'recaptcha')
 })
 
-test('recaptcha (body)', t => {
+test('recaptcha (url with gstatic.com/recaptcha)', t => {
+  const url = 'https://www.gstatic.com/recaptcha/releases/abc/recaptcha.js'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'recaptcha')
+})
+
+test('recaptcha (url with recaptcha.net)', t => {
+  const url = 'https://recaptcha.net/recaptcha/api.js'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'recaptcha')
+})
+
+test('recaptcha (body grecaptcha)', t => {
   const body = '<script>grecaptcha.execute();</script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'recaptcha')
+})
+
+test('recaptcha (body g-recaptcha)', t => {
+  const body = '<div class="g-recaptcha" data-sitekey="test"></div>'
   const result = isAntibot({ body })
   t.is(result.detected, true)
   t.is(result.provider, 'recaptcha')
@@ -146,7 +349,14 @@ test('hcaptcha (url)', t => {
   t.is(result.provider, 'hcaptcha')
 })
 
-test('hcaptcha (body)', t => {
+test('hcaptcha (body hcaptcha)', t => {
+  const body = '<div data-hcaptcha="test"></div>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'hcaptcha')
+})
+
+test('hcaptcha (body h-captcha)', t => {
   const body = '<div class="h-captcha"></div>'
   const result = isAntibot({ body })
   t.is(result.detected, true)
@@ -195,11 +405,109 @@ test('geetest (body)', t => {
   t.is(result.provider, 'geetest')
 })
 
-test('cloudflare-turnstile (body)', t => {
+test('geetest (body with gt.js)', t => {
+  const body = '<script src="/static/gt.js"></script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'geetest')
+})
+
+test('cloudflare-turnstile (url)', t => {
+  const url = 'https://challenges.cloudflare.com/turnstile/v0/api.js'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'cloudflare-turnstile')
+})
+
+test('cloudflare-turnstile (body cf-turnstile)', t => {
   const body = '<div class="cf-turnstile"></div>'
   const result = isAntibot({ body })
   t.is(result.detected, true)
   t.is(result.provider, 'cloudflare-turnstile')
+})
+
+test('cloudflare-turnstile (body turnstile)', t => {
+  const body = '<script>window.turnstile.render();</script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'cloudflare-turnstile')
+})
+
+test('friendly-captcha (url)', t => {
+  const url = 'https://cdn.friendlycaptcha.com/modules/v2/widget.js'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'friendly-captcha')
+})
+
+test('friendly-captcha (body frc-captcha)', t => {
+  const body = '<div class="frc-captcha" data-sitekey="test"></div>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'friendly-captcha')
+})
+
+test('friendly-captcha (body friendlyChallenge)', t => {
+  const body = '<script>friendlyChallenge.render();</script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'friendly-captcha')
+})
+
+test('captcha-eu (url)', t => {
+  const url = 'https://www.captcha.eu/widget/api.js'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'captcha-eu')
+})
+
+test('captcha-eu (body CaptchaEU)', t => {
+  const body = '<script>CaptchaEU.render();</script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'captcha-eu')
+})
+
+test('captcha-eu (body captchaeu)', t => {
+  const body = '<div class="captchaeu-widget"></div>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'captcha-eu')
+})
+
+test('qcloud-captcha (url)', t => {
+  const url = 'https://turing.captcha.qcloud.com/tdc.js'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'qcloud-captcha')
+})
+
+test('qcloud-captcha (body TencentCaptcha)', t => {
+  const body = '<script>new TencentCaptcha("appid");</script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'qcloud-captcha')
+})
+
+test('qcloud-captcha (body turing.captcha)', t => {
+  const body = '<script src="//turing.captcha.gtimg.com/tdc.js"></script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'qcloud-captcha')
+})
+
+test('aliexpress-captcha (url)', t => {
+  const url = 'https://www.aliexpress.com/punish?x5secdata=abc123'
+  const result = isAntibot({ url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'aliexpress-captcha')
+})
+
+test('aliexpress-captcha (body)', t => {
+  const body = '<script>var x5secdata = "abc123";</script>'
+  const result = isAntibot({ body })
+  t.is(result.detected, true)
+  t.is(result.provider, 'aliexpress-captcha')
 })
 
 test('linkedin (got set-cookie as array)', t => {
@@ -242,46 +550,25 @@ test('aws-waf (header)', t => {
   t.is(result.provider, 'aws-waf')
 })
 
-test('aws-waf (body)', t => {
+test('aws-waf (body aws-waf)', t => {
   const body = '<script>aws-waf.init();</script>'
   const result = isAntibot({ body })
   t.is(result.detected, true)
   t.is(result.provider, 'aws-waf')
 })
 
-test('recaptcha (body with g-recaptcha)', t => {
-  const body = '<div class="g-recaptcha" data-sitekey="test"></div>'
+test('aws-waf (body awswaf)', t => {
+  const body = '<script src="/awswaf/challenge.js"></script>'
   const result = isAntibot({ body })
   t.is(result.detected, true)
-  t.is(result.provider, 'recaptcha')
+  t.is(result.provider, 'aws-waf')
 })
 
-test('hcaptcha (body with hcaptcha)', t => {
-  const body = '<div data-hcaptcha="test"></div>'
-  const result = isAntibot({ body })
+test('aws-waf (aws-waf-token set-cookie)', t => {
+  const headers = { 'set-cookie': 'aws-waf-token=abc123; path=/' }
+  const result = isAntibot({ headers })
   t.is(result.detected, true)
-  t.is(result.provider, 'hcaptcha')
-})
-
-test('geetest (body with gt.js)', t => {
-  const body = '<script src="/static/gt.js"></script>'
-  const result = isAntibot({ body })
-  t.is(result.detected, true)
-  t.is(result.provider, 'geetest')
-})
-
-test('cloudflare-turnstile (url)', t => {
-  const url = 'https://challenges.cloudflare.com/turnstile/v0/api.js'
-  const result = isAntibot({ url })
-  t.is(result.detected, true)
-  t.is(result.provider, 'cloudflare-turnstile')
-})
-
-test('cloudflare-turnstile (body with turnstile)', t => {
-  const body = '<script>window.turnstile.render();</script>'
-  const result = isAntibot({ body })
-  t.is(result.detected, true)
-  t.is(result.provider, 'cloudflare-turnstile')
+  t.is(result.provider, 'aws-waf')
 })
 
 test('testPattern with invalid regex catches error', t => {


### PR DESCRIPTION
New antibot providers: Reblaze, Cheq, Sucuri, ThreatMetrix, Meetrics, Ocule. New captcha providers: Friendly Captcha, Captcha.eu, QCloud (Tencent), AliExpress. Enhanced detection for: Cloudflare, Akamai, DataDome, PerimeterX, Imperva, reCAPTCHA, AWS WAF with additional set-cookie, body, and URL signals.

Based on scrapfly/Antibot-Detector@48f426fd7e8e1424cd63b246830bb7d6b96d7100

Made-with: Cursor