### PR TITLE
feat: report detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ const isAntibot = require('is-antibot')
 const response = await fetch('https://www.linkedin.com/in/kikobeats/')
 const html = await response.text()
 
-const { detected, provider } = isAntibot({
+const { detected, provider, technique } = isAntibot({
   headers: response.headers,
   html,
   url: response.url
 })
 
 if (detected) {
-  console.log(`Antibot detected: ${provider}`)
+  console.log(`Antibot detected: ${provider} via ${technique}`)
 }
 ```
 
@@ -84,10 +84,10 @@ It also works with [got](https://github.com/sindresorhus/got) or any library whe
 const response = await got('https://www.linkedin.com/in/kikobeats/')
   .catch(error => errorresponse)
 
-const { detected, provider } = isAntibot(response)
+const { detected, provider, technique } = isAntibot(response)
 
 if (detected) {
-  console.log(`Antibot detected: ${provider}`)
+  console.log(`Antibot detected: ${provider} via ${technique}`)
 }
 ```
 
@@ -95,6 +95,7 @@ The library returns an object with the following properties:
 
 - `detected` (boolean): Whether an antibot challenge was detected
 - `provider` (string|null): The name of the detected provider (e.g., 'cloudflare', 'recaptcha')
+- `technique` (string|null): Where the signal came from: `'headers'`, `'cookies'`, `'html'`, or `'url'`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ const isAntibot = require('is-antibot')
 const response = await fetch('https://www.linkedin.com/in/kikobeats/')
 const html = await response.text()
 
-const { detected, provider, technique } = isAntibot({
+const { detected, provider, detection } = isAntibot({
   headers: response.headers,
   html,
   url: response.url
 })
 
 if (detected) {
-  console.log(`Antibot detected: ${provider} via ${technique}`)
+  console.log(`Antibot detected: ${provider} via ${detection}`)
 }
 ```
 
@@ -84,10 +84,10 @@ It also works with [got](https://github.com/sindresorhus/got) or any library whe
 const response = await got('https://www.linkedin.com/in/kikobeats/')
   .catch(error => errorresponse)
 
-const { detected, provider, technique } = isAntibot(response)
+const { detected, provider, detection } = isAntibot(response)
 
 if (detected) {
-  console.log(`Antibot detected: ${provider} via ${technique}`)
+  console.log(`Antibot detected: ${provider} via ${detection}`)
 }
 ```
 
@@ -95,7 +95,7 @@ The library returns an object with the following properties:
 
 - `detected` (boolean): Whether an antibot challenge was detected
 - `provider` (string|null): The name of the detected provider (e.g., 'cloudflare', 'recaptcha')
-- `technique` (string|null): Where the signal came from: `'headers'`, `'cookies'`, `'html'`, or `'url'`
+- `detection` (string|null): Where the signal came from: `'headers'`, `'cookies'`, `'html'`, or `'url'`
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,8 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   const hasAnyCookie = cookieNames =>
     cookieNames.some(cookieName => hasCookie(cookieName))
 
-  const hasAnyHtml = patterns => patterns.some(pattern => htmlHas(pattern))
+  const hasAnyHtml = (patterns, isRegex = false) =>
+    patterns.some(pattern => htmlHas(pattern, isRegex))
 
   const hasAnyUrl = (...patterns) => patterns.some(pattern => urlHas(pattern))
 
@@ -110,7 +111,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // Akamai: Bot Manager API namespace (bmak) in html
-  if (htmlHas('bmak.')) {
+  if (hasAnyHtml(['bmak.'])) {
     return byHtml('akamai')
   }
 
@@ -160,7 +161,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // Shape Security: Check for 'shapesecurity' text in response html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-shapesecurity.json
-  if (htmlHas('shapesecurity')) {
+  if (hasAnyHtml(['shapesecurity'])) {
     return byHtml('shapesecurity')
   }
 
@@ -201,7 +202,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // Reblaze: Check for 'reblaze' text in response html
-  if (htmlHas('reblaze')) {
+  if (hasAnyHtml(['reblaze'])) {
     return byHtml('reblaze')
   }
 
@@ -218,13 +219,13 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // Sucuri: Check for 'sucuri' text in response html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-sucuri.json
-  if (htmlHas('sucuri')) {
+  if (hasAnyHtml(['sucuri'])) {
     return byHtml('sucuri')
   }
 
   // ThreatMetrix: Check for 'ThreatMetrix' in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-threatmetrix.json
-  if (htmlHas('ThreatMetrix')) {
+  if (hasAnyHtml(['ThreatMetrix'])) {
     return byHtml('threatmetrix')
   }
 
@@ -235,7 +236,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // Meetrics: Check for 'meetrics' text in response html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-meetrics.json
-  if (htmlHas('meetrics')) {
+  if (hasAnyHtml(['meetrics'])) {
     return byHtml('meetrics')
   }
 
@@ -246,7 +247,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // Ocule: Check for ocule.co.uk in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-ocule.json
-  if (htmlHas('ocule.co.uk')) {
+  if (hasAnyHtml(['ocule.co.uk'])) {
     return byHtml('ocule')
   }
 
@@ -267,19 +268,21 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   // reCAPTCHA: Check for grecaptcha API usage in html (JavaScript indicator)
   // Note: plain "grecaptcha" is too broad (e.g. ".grecaptcha-badge" CSS appears on normal YouTube pages)
   if (
-    htmlHas(
-      '\\b(?:window\\.)?grecaptcha\\s*\\.(?:execute|render|ready|getResponse|enterprise)\\b',
+    hasAnyHtml(
+      [
+        '\\b(?:window\\.)?grecaptcha\\s*\\.(?:execute|render|ready|getResponse|enterprise)\\b',
+        '\\b(?:window\\.)?grecaptcha\\s*\\(',
+        '\\b__grecaptcha_cfg\\b'
+      ],
       true
-    ) ||
-    htmlHas('\\b(?:window\\.)?grecaptcha\\s*\\(', true) ||
-    htmlHas('\\b__grecaptcha_cfg\\b', true)
+    )
   ) {
     return byHtml('recaptcha')
   }
 
   // reCAPTCHA: Check for g-recaptcha container class in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-recaptcha.json
-  if (htmlHas('g-recaptcha')) {
+  if (hasAnyHtml(['g-recaptcha'])) {
     return byHtml('recaptcha')
   }
 
@@ -318,7 +321,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   // GeeTest: Check for geetest object or text in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-geetest.json
   // Note: bare 'gt.js' removed (too generic, any script named gt.js would match)
-  if (htmlHas('geetest')) {
+  if (hasAnyHtml(['geetest'])) {
     return byHtml('geetest')
   }
 
@@ -373,7 +376,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // AliExpress CAPTCHA: Check for x5secdata in html
-  if (htmlHas('x5secdata')) {
+  if (hasAnyHtml(['x5secdata'])) {
     return byHtml('aliexpress-captcha')
   }
 
@@ -384,7 +387,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // YouTube: empty title pattern indicates a degraded response requiring BotGuard JS attestation
   // Normal pages have `<title>Video Title - YouTube</title>`, bots get `<title> - YouTube</title>`
-  if (htmlHas('<title>\\s*-\\s*YouTube<\\/title>', true)) {
+  if (hasAnyHtml(['<title>\\s*-\\s*YouTube<\\/title>'], true)) {
     return byHtml('youtube')
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,14 @@ const createTestPattern = value => {
   if (!value) return () => false
   const lowerValue = value.toLowerCase()
   return (pattern, isRegex = false) => {
+    if (pattern instanceof RegExp) {
+      try {
+        return pattern.test(value)
+      } catch {
+        return false
+      }
+    }
+
     if (isRegex) {
       try {
         return new RegExp(pattern, 'i').test(value)
@@ -60,13 +68,9 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   const hasAnyCookie = cookieNames =>
     cookieNames.some(cookieName => hasCookie(cookieName))
 
-  const hasAnyHtml = (patterns, isRegex = false) =>
-    patterns.some(pattern => htmlHas(pattern, isRegex))
+  const hasAnyHtml = patterns => patterns.some(pattern => htmlHas(pattern))
 
-  const hasAnyUrl = (...patterns) => patterns.some(pattern => urlHas(pattern))
-
-  const hasAnyUrlRegex = (...patterns) =>
-    patterns.some(pattern => urlHas(pattern, true))
+  const hasAnyUrl = patterns => patterns.some(pattern => urlHas(pattern))
 
   const byHeaders = provider => createResult(true, provider, DETECTION.HEADERS)
 
@@ -83,7 +87,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // Cloudflare: cf_clearance cookie indicates Cloudflare challenge flow
-  if (hasCookie('cf_clearance=')) {
+  if (hasAnyCookie(['cf_clearance='])) {
     return byCookies('cloudflare')
   }
 
@@ -106,7 +110,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // Akamai: _abck bot manager tracking cookie
-  if (hasCookie('_abck=')) {
+  if (hasAnyCookie(['_abck='])) {
     return byCookies('akamai')
   }
 
@@ -128,7 +132,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // DataDome: datadome tracking cookie
-  if (hasCookie('datadome=')) {
+  if (hasAnyCookie(['datadome='])) {
     return byCookies('datadome')
   }
 
@@ -213,7 +217,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // Cheq: Check for cheqzone.com or cheq.ai in URL
-  if (hasAnyUrlRegex('cheqzone\\.com', 'cheq\\.ai')) {
+  if (hasAnyUrl([/cheqzone\.com/i, /cheq\.ai/i])) {
     return byUrl('cheq')
   }
 
@@ -230,7 +234,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // ThreatMetrix: Check for fp/check.js fingerprint endpoint in URL
-  if (hasAnyUrl('fp/check.js')) {
+  if (hasAnyUrl(['fp/check.js'])) {
     return byUrl('threatmetrix')
   }
 
@@ -241,7 +245,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // Meetrics: Check for meetrics.com in URL
-  if (urlHas('meetrics\\.com', true)) {
+  if (hasAnyUrl([/meetrics\.com/i])) {
     return byUrl('meetrics')
   }
 
@@ -252,15 +256,15 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // Ocule: Check for ocule.co.uk in URL
-  if (urlHas('ocule\\.co\\.uk', true)) {
+  if (hasAnyUrl([/ocule\.co\.uk/i])) {
     return byUrl('ocule')
   }
 
   // reCAPTCHA: Check for recaptcha/api, google.com/recaptcha, gstatic.com/recaptcha, or recaptcha.net in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-recaptcha.json
   if (
-    hasAnyUrl('recaptcha/api', 'gstatic.com/recaptcha', 'recaptcha.net') ||
-    hasAnyUrlRegex('google\\.com/recaptcha')
+    hasAnyUrl(['recaptcha/api', 'gstatic.com/recaptcha', 'recaptcha.net']) ||
+    hasAnyUrl([/google\.com\/recaptcha/i])
   ) {
     return byUrl('recaptcha')
   }
@@ -268,14 +272,11 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   // reCAPTCHA: Check for grecaptcha API usage in html (JavaScript indicator)
   // Note: plain "grecaptcha" is too broad (e.g. ".grecaptcha-badge" CSS appears on normal YouTube pages)
   if (
-    hasAnyHtml(
-      [
-        '\\b(?:window\\.)?grecaptcha\\s*\\.(?:execute|render|ready|getResponse|enterprise)\\b',
-        '\\b(?:window\\.)?grecaptcha\\s*\\(',
-        '\\b__grecaptcha_cfg\\b'
-      ],
-      true
-    )
+    hasAnyHtml([
+      /\b(?:window\.)?grecaptcha\s*\.(?:execute|render|ready|getResponse|enterprise)\b/i,
+      /\b(?:window\.)?grecaptcha\s*\(/i,
+      /\b__grecaptcha_cfg\b/i
+    ])
   ) {
     return byHtml('recaptcha')
   }
@@ -288,7 +289,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // hCaptcha: Check for hcaptcha.com domain in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-hcaptcha.json
-  if (urlHas('hcaptcha\\.com', true)) {
+  if (hasAnyUrl([/hcaptcha\.com/i])) {
     return byUrl('hcaptcha')
   }
 
@@ -301,7 +302,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // FunCaptcha (Arkose Labs): Check for arkoselabs.com or funcaptcha in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-funcaptcha.json
-  if (urlHas('arkoselabs\\.com', true) || urlHas('funcaptcha')) {
+  if (hasAnyUrl([/arkoselabs\.com/i]) || hasAnyUrl(['funcaptcha'])) {
     return byUrl('funcaptcha')
   }
 
@@ -314,7 +315,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // GeeTest: Check for geetest.com domain in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-geetest.json
-  if (urlHas('geetest\\.com', true)) {
+  if (hasAnyUrl([/geetest\.com/i])) {
     return byUrl('geetest')
   }
 
@@ -326,7 +327,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // Cloudflare Turnstile: Check for challenges.cloudflare.com/turnstile in URL
-  if (urlHas('challenges\\.cloudflare\\.com/turnstile', true)) {
+  if (hasAnyUrl([/challenges\.cloudflare\.com\/turnstile/i])) {
     return byUrl('cloudflare-turnstile')
   }
 
@@ -338,7 +339,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // Friendly Captcha: Check for friendlycaptcha.com in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-friendlycaptcha.json
-  if (urlHas('friendlycaptcha\\.com', true)) {
+  if (hasAnyUrl([/friendlycaptcha\.com/i])) {
     return byUrl('friendly-captcha')
   }
 
@@ -349,7 +350,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // Captcha.eu: Check for captcha.eu in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-captchaeu.json
-  if (urlHas('captcha\\.eu', true)) {
+  if (hasAnyUrl([/captcha\.eu/i])) {
     return byUrl('captcha-eu')
   }
 
@@ -360,7 +361,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // QCloud Captcha (Tencent): Check for turing.captcha.qcloud.com in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-qcloud.json
-  if (urlHas('turing\\.captcha\\.qcloud\\.com', true)) {
+  if (hasAnyUrl([/turing\.captcha\.qcloud\.com/i])) {
     return byUrl('qcloud-captcha')
   }
 
@@ -371,7 +372,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 
   // AliExpress CAPTCHA: Check for punish?x5secdata in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-aliexpress.json
-  if (urlHas('punish\\?x5secdata', true)) {
+  if (hasAnyUrl([/punish\?x5secdata/i])) {
     return byUrl('aliexpress-captcha')
   }
 
@@ -381,13 +382,13 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // LinkedIn: trkCode=bf cookie ("bot filter") is set when LinkedIn blocks a request
-  if (hasCookie('trkCode=bf')) {
+  if (hasAnyCookie(['trkCode=bf'])) {
     return byCookies('linkedin')
   }
 
   // YouTube: empty title pattern indicates a degraded response requiring BotGuard JS attestation
   // Normal pages have `<title>Video Title - YouTube</title>`, bots get `<title> - YouTube</title>`
-  if (hasAnyHtml(['<title>\\s*-\\s*YouTube<\\/title>'], true)) {
+  if (hasAnyHtml([/<title>\s*-\s*YouTube<\/title>/i])) {
     return byHtml('youtube')
   }
 
@@ -403,7 +404,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   }
 
   // AWS WAF: aws-waf-token cookie
-  if (hasCookie('aws-waf-token=')) {
+  if (hasAnyCookie(['aws-waf-token='])) {
     return byCookies('aws-waf')
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,16 @@ const createTestPattern = value => {
   }
 }
 
-const createResult = (detected, provider) => {
-  debug({ detected, provider })
-  return { detected, provider }
+const TECHNIQUE = {
+  HEADERS: 'headers',
+  COOKIES: 'cookies',
+  HTML: 'html',
+  URL: 'url'
+}
+
+const createResult = (detected, provider, technique = null) => {
+  debug({ detected, provider, technique })
+  return { detected, provider, technique }
 }
 
 const createHasCookie = headers => {
@@ -38,81 +45,94 @@ const createHasCookie = headers => {
 
 const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   const getHeader = createGetHeader(headers)
+
   const hasCookie = createHasCookie(headers)
+
   const htmlHas = createTestPattern(html)
+
   const urlHas = createTestPattern(url)
+
+  const detectByHeaders = provider =>
+    createResult(true, provider, TECHNIQUE.HEADERS)
+
+  const detectByCookies = provider =>
+    createResult(true, provider, TECHNIQUE.COOKIES)
+
+  const detectByHtml = provider => createResult(true, provider, TECHNIQUE.HTML)
+
+  const detectByUrl = provider => createResult(true, provider, TECHNIQUE.URL)
 
   // CloudFlare: Check for cf-mitigated header with 'challenge' value
   // Official docs: https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/
   if (getHeader('cf-mitigated') === 'challenge') {
-    return createResult(true, 'cloudflare')
+    return detectByHeaders('cloudflare')
   }
 
   // Cloudflare: cf_clearance cookie indicates Cloudflare challenge flow
   if (hasCookie('cf_clearance=')) {
-    return createResult(true, 'cloudflare')
+    return detectByCookies('cloudflare')
   }
 
   // Vercel: Check for x-vercel-mitigated header with 'challenge' value
   // Solver reference: https://github.com/glizzykingdreko/Vercel-Attack-Mode-Solver
   if (getHeader('x-vercel-mitigated') === 'challenge') {
-    return createResult(true, 'vercel')
+    return detectByHeaders('vercel')
   }
 
   // Akamai: Check for akamai-cache-status header starting with 'Error'
   // Official docs: https://techdocs.akamai.com/property-mgr/docs/return-cache-status
   if (getHeader('akamai-cache-status')?.startsWith('Error')) {
-    return createResult(true, 'akamai')
+    return detectByHeaders('akamai')
   }
 
   // Akamai: Check for additional identifying headers (akamai-grn, x-akamai-session-info)
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-akamai.json
   if (getHeader('akamai-grn') || getHeader('x-akamai-session-info')) {
-    return createResult(true, 'akamai')
+    return detectByHeaders('akamai')
   }
 
   // Akamai: _abck bot manager tracking cookie
   if (hasCookie('_abck=')) {
-    return createResult(true, 'akamai')
+    return detectByCookies('akamai')
   }
 
   // Akamai: Bot Manager API namespace (bmak) in html
   if (htmlHas('bmak.')) {
-    return createResult(true, 'akamai')
+    return detectByHtml('akamai')
   }
 
   // DataDome: Check for x-dd-b header with values '1' (soft challenge) or '2' (hard challenge/CAPTCHA)
   // Official docs: https://docs.datadome.co/reference/validate-request
   if (['1', '2'].includes(getHeader('x-dd-b'))) {
-    return createResult(true, 'datadome')
+    return detectByHeaders('datadome')
   }
 
   // DataDome: Check for x-datadome or x-datadome-cid header presence
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-datadome.json
   if (getHeader('x-datadome') || getHeader('x-datadome-cid')) {
-    return createResult(true, 'datadome')
+    return detectByHeaders('datadome')
   }
 
   // DataDome: datadome tracking cookie
   if (hasCookie('datadome=')) {
-    return createResult(true, 'datadome')
+    return detectByCookies('datadome')
   }
 
   // PerimeterX: Check for X-PX-Authorization header (primary indicator)
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-perimeterx.json
   if (getHeader('x-px-authorization')) {
-    return createResult(true, 'perimeterx')
+    return detectByHeaders('perimeterx')
   }
 
   // PerimeterX: Check for window._pxAppId, pxInit, or _pxAction in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-perimeterx.json
   if (htmlHas('window._pxAppId') || htmlHas('pxInit') || htmlHas('_pxAction')) {
-    return createResult(true, 'perimeterx')
+    return detectByHtml('perimeterx')
   }
 
   // PerimeterX: _px3 or _pxhd cookies
   if (hasCookie('_px3=') || hasCookie('_pxhd=')) {
-    return createResult(true, 'perimeterx')
+    return detectByCookies('perimeterx')
   }
 
   // Shape Security: Check for dynamic header patterns x-[8chars]-[abcdfz]
@@ -121,38 +141,38 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   const headerNames = Object.keys(headers)
   for (const name of headerNames) {
     if (/^x-[a-z0-9]{8}-[abcdfz]$/i.test(name)) {
-      return createResult(true, 'shapesecurity')
+      return detectByHeaders('shapesecurity')
     }
   }
 
   // Shape Security: Check for 'shapesecurity' text in response html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-shapesecurity.json
   if (htmlHas('shapesecurity')) {
-    return createResult(true, 'shapesecurity')
+    return detectByHtml('shapesecurity')
   }
 
   // Kasada: Check for x-kasada or x-kasada-challenge headers
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-kasada.json
   if (getHeader('x-kasada') || getHeader('x-kasada-challenge')) {
-    return createResult(true, 'kasada')
+    return detectByHeaders('kasada')
   }
 
   // Kasada: Check for __kasada global object or kasada.js script in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-kasada.json
   if (htmlHas('__kasada') || htmlHas('kasada.js')) {
-    return createResult(true, 'kasada')
+    return detectByHtml('kasada')
   }
 
   // Imperva/Incapsula: Check for x-cdn header with 'Incapsula' value or x-iinfo header
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-incapsula.json
   if (getHeader('x-cdn') === 'Incapsula' || getHeader('x-iinfo')) {
-    return createResult(true, 'imperva')
+    return detectByHeaders('imperva')
   }
 
   // Imperva/Incapsula: Check for 'incapsula' or 'imperva' text in response html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-incapsula.json
   if (htmlHas('incapsula') || htmlHas('imperva')) {
-    return createResult(true, 'imperva')
+    return detectByHtml('imperva')
   }
 
   // Imperva/Incapsula: incap_ses_, visid_incap_, or reese84 cookies
@@ -162,68 +182,68 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
     hasCookie('visid_incap_') ||
     hasCookie('reese84=')
   ) {
-    return createResult(true, 'imperva')
+    return detectByCookies('imperva')
   }
 
   // Reblaze: rbzid or rbzsessionid cookies
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-reblaze.json
   if (hasCookie('rbzid=') || hasCookie('rbzsessionid=')) {
-    return createResult(true, 'reblaze')
+    return detectByCookies('reblaze')
   }
 
   // Reblaze: Check for 'reblaze' text in response html
   if (htmlHas('reblaze')) {
-    return createResult(true, 'reblaze')
+    return detectByHtml('reblaze')
   }
 
   // Cheq: Check for CheqSdk or cheqzone.com in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-cheq.json
   if (htmlHas('CheqSdk') || htmlHas('cheqzone.com')) {
-    return createResult(true, 'cheq')
+    return detectByHtml('cheq')
   }
 
   // Cheq: Check for cheqzone.com or cheq.ai in URL
   if (urlHas('cheqzone\\.com', true) || urlHas('cheq\\.ai', true)) {
-    return createResult(true, 'cheq')
+    return detectByUrl('cheq')
   }
 
   // Sucuri: Check for 'sucuri' text in response html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-sucuri.json
   if (htmlHas('sucuri')) {
-    return createResult(true, 'sucuri')
+    return detectByHtml('sucuri')
   }
 
   // ThreatMetrix: Check for 'ThreatMetrix' in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-threatmetrix.json
   if (htmlHas('ThreatMetrix')) {
-    return createResult(true, 'threatmetrix')
+    return detectByHtml('threatmetrix')
   }
 
   // ThreatMetrix: Check for fp/check.js fingerprint endpoint in URL
   if (urlHas('fp/check.js')) {
-    return createResult(true, 'threatmetrix')
+    return detectByUrl('threatmetrix')
   }
 
   // Meetrics: Check for 'meetrics' text in response html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-meetrics.json
   if (htmlHas('meetrics')) {
-    return createResult(true, 'meetrics')
+    return detectByHtml('meetrics')
   }
 
   // Meetrics: Check for meetrics.com in URL
   if (urlHas('meetrics\\.com', true)) {
-    return createResult(true, 'meetrics')
+    return detectByUrl('meetrics')
   }
 
   // Ocule: Check for ocule.co.uk in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-ocule.json
   if (htmlHas('ocule.co.uk')) {
-    return createResult(true, 'ocule')
+    return detectByHtml('ocule')
   }
 
   // Ocule: Check for ocule.co.uk in URL
   if (urlHas('ocule\\.co\\.uk', true)) {
-    return createResult(true, 'ocule')
+    return detectByUrl('ocule')
   }
 
   // reCAPTCHA: Check for recaptcha/api, google.com/recaptcha, gstatic.com/recaptcha, or recaptcha.net in URL
@@ -234,7 +254,7 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
     urlHas('gstatic.com/recaptcha') ||
     urlHas('recaptcha.net')
   ) {
-    return createResult(true, 'recaptcha')
+    return detectByUrl('recaptcha')
   }
 
   // reCAPTCHA: Check for grecaptcha API usage in html (JavaScript indicator)
@@ -247,57 +267,57 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
     htmlHas('\\b(?:window\\.)?grecaptcha\\s*\\(', true) ||
     htmlHas('\\b__grecaptcha_cfg\\b', true)
   ) {
-    return createResult(true, 'recaptcha')
+    return detectByHtml('recaptcha')
   }
 
   // reCAPTCHA: Check for g-recaptcha container class in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-recaptcha.json
   if (htmlHas('g-recaptcha')) {
-    return createResult(true, 'recaptcha')
+    return detectByHtml('recaptcha')
   }
 
   // hCaptcha: Check for hcaptcha.com domain in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-hcaptcha.json
   if (urlHas('hcaptcha\\.com', true)) {
-    return createResult(true, 'hcaptcha')
+    return detectByUrl('hcaptcha')
   }
 
   // hCaptcha: Check for hcaptcha.com API domain or h-captcha container class in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-hcaptcha.json
   // Note: bare 'hcaptcha' matches too broadly (could appear in articles discussing hCaptcha)
   if (htmlHas('hcaptcha.com') || htmlHas('h-captcha')) {
-    return createResult(true, 'hcaptcha')
+    return detectByHtml('hcaptcha')
   }
 
   // FunCaptcha (Arkose Labs): Check for arkoselabs.com or funcaptcha in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-funcaptcha.json
   if (urlHas('arkoselabs\\.com', true) || urlHas('funcaptcha')) {
-    return createResult(true, 'funcaptcha')
+    return detectByUrl('funcaptcha')
   }
 
   // FunCaptcha (Arkose Labs): Check for arkoselabs.com API domain or funcaptcha in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-funcaptcha.json
   // Note: bare 'arkose' matches too broadly (e.g. Facebook bundles Arkose SDK for login without blocking content)
   if (htmlHas('arkoselabs.com') || htmlHas('funcaptcha')) {
-    return createResult(true, 'funcaptcha')
+    return detectByHtml('funcaptcha')
   }
 
   // GeeTest: Check for geetest.com domain in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-geetest.json
   if (urlHas('geetest\\.com', true)) {
-    return createResult(true, 'geetest')
+    return detectByUrl('geetest')
   }
 
   // GeeTest: Check for geetest object or text in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-geetest.json
   // Note: bare 'gt.js' removed (too generic, any script named gt.js would match)
   if (htmlHas('geetest')) {
-    return createResult(true, 'geetest')
+    return detectByHtml('geetest')
   }
 
   // Cloudflare Turnstile: Check for challenges.cloudflare.com/turnstile in URL
   if (urlHas('challenges\\.cloudflare\\.com/turnstile', true)) {
-    return createResult(true, 'cloudflare-turnstile')
+    return detectByUrl('cloudflare-turnstile')
   }
 
   // Cloudflare Turnstile: Check for cf-turnstile class or turnstile API script in html
@@ -306,81 +326,81 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
     htmlHas('cf-turnstile') ||
     htmlHas('challenges.cloudflare.com/turnstile')
   ) {
-    return createResult(true, 'cloudflare-turnstile')
+    return detectByHtml('cloudflare-turnstile')
   }
 
   // Friendly Captcha: Check for friendlycaptcha.com in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-friendlycaptcha.json
   if (urlHas('friendlycaptcha\\.com', true)) {
-    return createResult(true, 'friendly-captcha')
+    return detectByUrl('friendly-captcha')
   }
 
   // Friendly Captcha: Check for frc-captcha container or friendlyChallenge object in html
   if (htmlHas('frc-captcha') || htmlHas('friendlyChallenge')) {
-    return createResult(true, 'friendly-captcha')
+    return detectByHtml('friendly-captcha')
   }
 
   // Captcha.eu: Check for captcha.eu in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-captchaeu.json
   if (urlHas('captcha\\.eu', true)) {
-    return createResult(true, 'captcha-eu')
+    return detectByUrl('captcha-eu')
   }
 
   // Captcha.eu: Check for CaptchaEU or captchaeu in html
   if (htmlHas('CaptchaEU') || htmlHas('captchaeu')) {
-    return createResult(true, 'captcha-eu')
+    return detectByHtml('captcha-eu')
   }
 
   // QCloud Captcha (Tencent): Check for turing.captcha.qcloud.com in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-qcloud.json
   if (urlHas('turing\\.captcha\\.qcloud\\.com', true)) {
-    return createResult(true, 'qcloud-captcha')
+    return detectByUrl('qcloud-captcha')
   }
 
   // QCloud Captcha: Check for TencentCaptcha or turing.captcha in html
   if (htmlHas('TencentCaptcha') || htmlHas('turing.captcha')) {
-    return createResult(true, 'qcloud-captcha')
+    return detectByHtml('qcloud-captcha')
   }
 
   // AliExpress CAPTCHA: Check for punish?x5secdata in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-aliexpress.json
   if (urlHas('punish\\?x5secdata', true)) {
-    return createResult(true, 'aliexpress-captcha')
+    return detectByUrl('aliexpress-captcha')
   }
 
   // AliExpress CAPTCHA: Check for x5secdata in html
   if (htmlHas('x5secdata')) {
-    return createResult(true, 'aliexpress-captcha')
+    return detectByHtml('aliexpress-captcha')
   }
 
   // LinkedIn: trkCode=bf cookie ("bot filter") is set when LinkedIn blocks a request
   if (hasCookie('trkCode=bf')) {
-    return createResult(true, 'linkedin')
+    return detectByCookies('linkedin')
   }
 
   // YouTube: empty title pattern indicates a degraded response requiring BotGuard JS attestation
   // Normal pages have `<title>Video Title - YouTube</title>`, bots get `<title> - YouTube</title>`
   if (htmlHas('<title>\\s*-\\s*YouTube<\\/title>', true)) {
-    return createResult(true, 'youtube')
+    return detectByHtml('youtube')
   }
 
   // AWS WAF: Check for x-amzn-waf-action or x-amzn-requestid headers
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-aws-waf.json
   if (getHeader('x-amzn-waf-action') || getHeader('x-amzn-requestid')) {
-    return createResult(true, 'aws-waf')
+    return detectByHeaders('aws-waf')
   }
 
   // AWS WAF: Check for aws-waf or awswaf text in html
   if (htmlHas('aws-waf') || htmlHas('awswaf')) {
-    return createResult(true, 'aws-waf')
+    return detectByHtml('aws-waf')
   }
 
   // AWS WAF: aws-waf-token cookie
   if (hasCookie('aws-waf-token=')) {
-    return createResult(true, 'aws-waf')
+    return detectByCookies('aws-waf')
   }
 
-  return createResult(false, null)
+  return createResult(false, null, null)
 }
 
 const isAntibot = (input = {}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,13 @@
 const { splitSetCookieString } = require('cookie-es')
 const debug = require('debug-logfmt')('is-antibot')
 
+const DETECTION = {
+  HEADERS: 'headers',
+  COOKIES: 'cookies',
+  HTML: 'html',
+  URL: 'url'
+}
+
 const createGetHeader = headers =>
   typeof headers.get === 'function'
     ? name => headers.get(name)
@@ -23,16 +30,9 @@ const createTestPattern = value => {
   }
 }
 
-const TECHNIQUE = {
-  HEADERS: 'headers',
-  COOKIES: 'cookies',
-  HTML: 'html',
-  URL: 'url'
-}
-
-const createResult = (detected, provider, technique = null) => {
-  debug({ detected, provider, technique })
-  return { detected, provider, technique }
+const createResult = (detected, provider, detection = null) => {
+  debug({ detected, provider, detection })
+  return { detected, provider, detection }
 }
 
 const createHasCookie = headers => {
@@ -43,218 +43,225 @@ const createHasCookie = headers => {
     )
 }
 
+const getHeaderNames = headers =>
+  typeof headers.keys === 'function'
+    ? Array.from(headers.keys())
+    : Object.keys(headers)
+
 const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   const getHeader = createGetHeader(headers)
-
   const hasCookie = createHasCookie(headers)
-
   const htmlHas = createTestPattern(html)
-
   const urlHas = createTestPattern(url)
 
-  const detectByHeaders = provider =>
-    createResult(true, provider, TECHNIQUE.HEADERS)
+  const hasAnyHeader = headerNames =>
+    headerNames.some(headerName => getHeader(headerName))
 
-  const detectByCookies = provider =>
-    createResult(true, provider, TECHNIQUE.COOKIES)
+  const hasAnyCookie = cookieNames =>
+    cookieNames.some(cookieName => hasCookie(cookieName))
 
-  const detectByHtml = provider => createResult(true, provider, TECHNIQUE.HTML)
+  const hasAnyHtml = patterns => patterns.some(pattern => htmlHas(pattern))
 
-  const detectByUrl = provider => createResult(true, provider, TECHNIQUE.URL)
+  const hasAnyUrl = (...patterns) => patterns.some(pattern => urlHas(pattern))
+
+  const hasAnyUrlRegex = (...patterns) =>
+    patterns.some(pattern => urlHas(pattern, true))
+
+  const byHeaders = provider => createResult(true, provider, DETECTION.HEADERS)
+
+  const byCookies = provider => createResult(true, provider, DETECTION.COOKIES)
+
+  const byHtml = provider => createResult(true, provider, DETECTION.HTML)
+
+  const byUrl = provider => createResult(true, provider, DETECTION.URL)
 
   // CloudFlare: Check for cf-mitigated header with 'challenge' value
   // Official docs: https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/
   if (getHeader('cf-mitigated') === 'challenge') {
-    return detectByHeaders('cloudflare')
+    return byHeaders('cloudflare')
   }
 
   // Cloudflare: cf_clearance cookie indicates Cloudflare challenge flow
   if (hasCookie('cf_clearance=')) {
-    return detectByCookies('cloudflare')
+    return byCookies('cloudflare')
   }
 
   // Vercel: Check for x-vercel-mitigated header with 'challenge' value
   // Solver reference: https://github.com/glizzykingdreko/Vercel-Attack-Mode-Solver
   if (getHeader('x-vercel-mitigated') === 'challenge') {
-    return detectByHeaders('vercel')
+    return byHeaders('vercel')
   }
 
   // Akamai: Check for akamai-cache-status header starting with 'Error'
   // Official docs: https://techdocs.akamai.com/property-mgr/docs/return-cache-status
   if (getHeader('akamai-cache-status')?.startsWith('Error')) {
-    return detectByHeaders('akamai')
+    return byHeaders('akamai')
   }
 
   // Akamai: Check for additional identifying headers (akamai-grn, x-akamai-session-info)
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-akamai.json
-  if (getHeader('akamai-grn') || getHeader('x-akamai-session-info')) {
-    return detectByHeaders('akamai')
+  if (hasAnyHeader(['akamai-grn', 'x-akamai-session-info'])) {
+    return byHeaders('akamai')
   }
 
   // Akamai: _abck bot manager tracking cookie
   if (hasCookie('_abck=')) {
-    return detectByCookies('akamai')
+    return byCookies('akamai')
   }
 
   // Akamai: Bot Manager API namespace (bmak) in html
   if (htmlHas('bmak.')) {
-    return detectByHtml('akamai')
+    return byHtml('akamai')
   }
 
   // DataDome: Check for x-dd-b header with values '1' (soft challenge) or '2' (hard challenge/CAPTCHA)
   // Official docs: https://docs.datadome.co/reference/validate-request
   if (['1', '2'].includes(getHeader('x-dd-b'))) {
-    return detectByHeaders('datadome')
+    return byHeaders('datadome')
   }
 
   // DataDome: Check for x-datadome or x-datadome-cid header presence
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-datadome.json
-  if (getHeader('x-datadome') || getHeader('x-datadome-cid')) {
-    return detectByHeaders('datadome')
+  if (hasAnyHeader(['x-datadome', 'x-datadome-cid'])) {
+    return byHeaders('datadome')
   }
 
   // DataDome: datadome tracking cookie
   if (hasCookie('datadome=')) {
-    return detectByCookies('datadome')
+    return byCookies('datadome')
   }
 
   // PerimeterX: Check for X-PX-Authorization header (primary indicator)
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-perimeterx.json
   if (getHeader('x-px-authorization')) {
-    return detectByHeaders('perimeterx')
+    return byHeaders('perimeterx')
   }
 
   // PerimeterX: Check for window._pxAppId, pxInit, or _pxAction in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-perimeterx.json
-  if (htmlHas('window._pxAppId') || htmlHas('pxInit') || htmlHas('_pxAction')) {
-    return detectByHtml('perimeterx')
+  if (hasAnyHtml(['window._pxAppId', 'pxInit', '_pxAction'])) {
+    return byHtml('perimeterx')
   }
 
   // PerimeterX: _px3 or _pxhd cookies
-  if (hasCookie('_px3=') || hasCookie('_pxhd=')) {
-    return detectByCookies('perimeterx')
+  if (hasAnyCookie(['_px3=', '_pxhd='])) {
+    return byCookies('perimeterx')
   }
 
   // Shape Security: Check for dynamic header patterns x-[8chars]-[abcdfz]
   // These headers use 8 random characters followed by suffixes like -a, -b, -c, -d, -f, or -z
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-shapesecurity.json
-  const headerNames = Object.keys(headers)
+  const headerNames = getHeaderNames(headers)
   for (const name of headerNames) {
     if (/^x-[a-z0-9]{8}-[abcdfz]$/i.test(name)) {
-      return detectByHeaders('shapesecurity')
+      return byHeaders('shapesecurity')
     }
   }
 
   // Shape Security: Check for 'shapesecurity' text in response html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-shapesecurity.json
   if (htmlHas('shapesecurity')) {
-    return detectByHtml('shapesecurity')
+    return byHtml('shapesecurity')
   }
 
   // Kasada: Check for x-kasada or x-kasada-challenge headers
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-kasada.json
-  if (getHeader('x-kasada') || getHeader('x-kasada-challenge')) {
-    return detectByHeaders('kasada')
+  if (hasAnyHeader(['x-kasada', 'x-kasada-challenge'])) {
+    return byHeaders('kasada')
   }
 
   // Kasada: Check for __kasada global object or kasada.js script in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-kasada.json
-  if (htmlHas('__kasada') || htmlHas('kasada.js')) {
-    return detectByHtml('kasada')
+  if (hasAnyHtml(['__kasada', 'kasada.js'])) {
+    return byHtml('kasada')
   }
 
   // Imperva/Incapsula: Check for x-cdn header with 'Incapsula' value or x-iinfo header
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-incapsula.json
-  if (getHeader('x-cdn') === 'Incapsula' || getHeader('x-iinfo')) {
-    return detectByHeaders('imperva')
+  if (getHeader('x-cdn') === 'Incapsula' || hasAnyHeader(['x-iinfo'])) {
+    return byHeaders('imperva')
   }
 
   // Imperva/Incapsula: Check for 'incapsula' or 'imperva' text in response html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-incapsula.json
-  if (htmlHas('incapsula') || htmlHas('imperva')) {
-    return detectByHtml('imperva')
+  if (hasAnyHtml(['incapsula', 'imperva'])) {
+    return byHtml('imperva')
   }
 
   // Imperva/Incapsula: incap_ses_, visid_incap_, or reese84 cookies
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-incapsula.json
-  if (
-    hasCookie('incap_ses_') ||
-    hasCookie('visid_incap_') ||
-    hasCookie('reese84=')
-  ) {
-    return detectByCookies('imperva')
+  if (hasAnyCookie(['incap_ses_', 'visid_incap_', 'reese84='])) {
+    return byCookies('imperva')
   }
 
   // Reblaze: rbzid or rbzsessionid cookies
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-reblaze.json
-  if (hasCookie('rbzid=') || hasCookie('rbzsessionid=')) {
-    return detectByCookies('reblaze')
+  if (hasAnyCookie(['rbzid=', 'rbzsessionid='])) {
+    return byCookies('reblaze')
   }
 
   // Reblaze: Check for 'reblaze' text in response html
   if (htmlHas('reblaze')) {
-    return detectByHtml('reblaze')
+    return byHtml('reblaze')
   }
 
   // Cheq: Check for CheqSdk or cheqzone.com in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-cheq.json
-  if (htmlHas('CheqSdk') || htmlHas('cheqzone.com')) {
-    return detectByHtml('cheq')
+  if (hasAnyHtml(['CheqSdk', 'cheqzone.com'])) {
+    return byHtml('cheq')
   }
 
   // Cheq: Check for cheqzone.com or cheq.ai in URL
-  if (urlHas('cheqzone\\.com', true) || urlHas('cheq\\.ai', true)) {
-    return detectByUrl('cheq')
+  if (hasAnyUrlRegex('cheqzone\\.com', 'cheq\\.ai')) {
+    return byUrl('cheq')
   }
 
   // Sucuri: Check for 'sucuri' text in response html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-sucuri.json
   if (htmlHas('sucuri')) {
-    return detectByHtml('sucuri')
+    return byHtml('sucuri')
   }
 
   // ThreatMetrix: Check for 'ThreatMetrix' in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-threatmetrix.json
   if (htmlHas('ThreatMetrix')) {
-    return detectByHtml('threatmetrix')
+    return byHtml('threatmetrix')
   }
 
   // ThreatMetrix: Check for fp/check.js fingerprint endpoint in URL
-  if (urlHas('fp/check.js')) {
-    return detectByUrl('threatmetrix')
+  if (hasAnyUrl('fp/check.js')) {
+    return byUrl('threatmetrix')
   }
 
   // Meetrics: Check for 'meetrics' text in response html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-meetrics.json
   if (htmlHas('meetrics')) {
-    return detectByHtml('meetrics')
+    return byHtml('meetrics')
   }
 
   // Meetrics: Check for meetrics.com in URL
   if (urlHas('meetrics\\.com', true)) {
-    return detectByUrl('meetrics')
+    return byUrl('meetrics')
   }
 
   // Ocule: Check for ocule.co.uk in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-ocule.json
   if (htmlHas('ocule.co.uk')) {
-    return detectByHtml('ocule')
+    return byHtml('ocule')
   }
 
   // Ocule: Check for ocule.co.uk in URL
   if (urlHas('ocule\\.co\\.uk', true)) {
-    return detectByUrl('ocule')
+    return byUrl('ocule')
   }
 
   // reCAPTCHA: Check for recaptcha/api, google.com/recaptcha, gstatic.com/recaptcha, or recaptcha.net in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-recaptcha.json
   if (
-    urlHas('recaptcha/api') ||
-    urlHas('google\\.com/recaptcha', true) ||
-    urlHas('gstatic.com/recaptcha') ||
-    urlHas('recaptcha.net')
+    hasAnyUrl('recaptcha/api', 'gstatic.com/recaptcha', 'recaptcha.net') ||
+    hasAnyUrlRegex('google\\.com/recaptcha')
   ) {
-    return detectByUrl('recaptcha')
+    return byUrl('recaptcha')
   }
 
   // reCAPTCHA: Check for grecaptcha API usage in html (JavaScript indicator)
@@ -267,137 +274,134 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
     htmlHas('\\b(?:window\\.)?grecaptcha\\s*\\(', true) ||
     htmlHas('\\b__grecaptcha_cfg\\b', true)
   ) {
-    return detectByHtml('recaptcha')
+    return byHtml('recaptcha')
   }
 
   // reCAPTCHA: Check for g-recaptcha container class in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-recaptcha.json
   if (htmlHas('g-recaptcha')) {
-    return detectByHtml('recaptcha')
+    return byHtml('recaptcha')
   }
 
   // hCaptcha: Check for hcaptcha.com domain in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-hcaptcha.json
   if (urlHas('hcaptcha\\.com', true)) {
-    return detectByUrl('hcaptcha')
+    return byUrl('hcaptcha')
   }
 
   // hCaptcha: Check for hcaptcha.com API domain or h-captcha container class in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-hcaptcha.json
   // Note: bare 'hcaptcha' matches too broadly (could appear in articles discussing hCaptcha)
-  if (htmlHas('hcaptcha.com') || htmlHas('h-captcha')) {
-    return detectByHtml('hcaptcha')
+  if (hasAnyHtml(['hcaptcha.com', 'h-captcha'])) {
+    return byHtml('hcaptcha')
   }
 
   // FunCaptcha (Arkose Labs): Check for arkoselabs.com or funcaptcha in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-funcaptcha.json
   if (urlHas('arkoselabs\\.com', true) || urlHas('funcaptcha')) {
-    return detectByUrl('funcaptcha')
+    return byUrl('funcaptcha')
   }
 
   // FunCaptcha (Arkose Labs): Check for arkoselabs.com API domain or funcaptcha in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-funcaptcha.json
   // Note: bare 'arkose' matches too broadly (e.g. Facebook bundles Arkose SDK for login without blocking content)
-  if (htmlHas('arkoselabs.com') || htmlHas('funcaptcha')) {
-    return detectByHtml('funcaptcha')
+  if (hasAnyHtml(['arkoselabs.com', 'funcaptcha'])) {
+    return byHtml('funcaptcha')
   }
 
   // GeeTest: Check for geetest.com domain in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-geetest.json
   if (urlHas('geetest\\.com', true)) {
-    return detectByUrl('geetest')
+    return byUrl('geetest')
   }
 
   // GeeTest: Check for geetest object or text in html
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-geetest.json
   // Note: bare 'gt.js' removed (too generic, any script named gt.js would match)
   if (htmlHas('geetest')) {
-    return detectByHtml('geetest')
+    return byHtml('geetest')
   }
 
   // Cloudflare Turnstile: Check for challenges.cloudflare.com/turnstile in URL
   if (urlHas('challenges\\.cloudflare\\.com/turnstile', true)) {
-    return detectByUrl('cloudflare-turnstile')
+    return byUrl('cloudflare-turnstile')
   }
 
   // Cloudflare Turnstile: Check for cf-turnstile class or turnstile API script in html
   // Note: bare 'turnstile' matches too broadly (common English word)
-  if (
-    htmlHas('cf-turnstile') ||
-    htmlHas('challenges.cloudflare.com/turnstile')
-  ) {
-    return detectByHtml('cloudflare-turnstile')
+  if (hasAnyHtml(['cf-turnstile', 'challenges.cloudflare.com/turnstile'])) {
+    return byHtml('cloudflare-turnstile')
   }
 
   // Friendly Captcha: Check for friendlycaptcha.com in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-friendlycaptcha.json
   if (urlHas('friendlycaptcha\\.com', true)) {
-    return detectByUrl('friendly-captcha')
+    return byUrl('friendly-captcha')
   }
 
   // Friendly Captcha: Check for frc-captcha container or friendlyChallenge object in html
-  if (htmlHas('frc-captcha') || htmlHas('friendlyChallenge')) {
-    return detectByHtml('friendly-captcha')
+  if (hasAnyHtml(['frc-captcha', 'friendlyChallenge'])) {
+    return byHtml('friendly-captcha')
   }
 
   // Captcha.eu: Check for captcha.eu in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-captchaeu.json
   if (urlHas('captcha\\.eu', true)) {
-    return detectByUrl('captcha-eu')
+    return byUrl('captcha-eu')
   }
 
   // Captcha.eu: Check for CaptchaEU or captchaeu in html
-  if (htmlHas('CaptchaEU') || htmlHas('captchaeu')) {
-    return detectByHtml('captcha-eu')
+  if (hasAnyHtml(['CaptchaEU', 'captchaeu'])) {
+    return byHtml('captcha-eu')
   }
 
   // QCloud Captcha (Tencent): Check for turing.captcha.qcloud.com in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-qcloud.json
   if (urlHas('turing\\.captcha\\.qcloud\\.com', true)) {
-    return detectByUrl('qcloud-captcha')
+    return byUrl('qcloud-captcha')
   }
 
   // QCloud Captcha: Check for TencentCaptcha or turing.captcha in html
-  if (htmlHas('TencentCaptcha') || htmlHas('turing.captcha')) {
-    return detectByHtml('qcloud-captcha')
+  if (hasAnyHtml(['TencentCaptcha', 'turing.captcha'])) {
+    return byHtml('qcloud-captcha')
   }
 
   // AliExpress CAPTCHA: Check for punish?x5secdata in URL
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-aliexpress.json
   if (urlHas('punish\\?x5secdata', true)) {
-    return detectByUrl('aliexpress-captcha')
+    return byUrl('aliexpress-captcha')
   }
 
   // AliExpress CAPTCHA: Check for x5secdata in html
   if (htmlHas('x5secdata')) {
-    return detectByHtml('aliexpress-captcha')
+    return byHtml('aliexpress-captcha')
   }
 
   // LinkedIn: trkCode=bf cookie ("bot filter") is set when LinkedIn blocks a request
   if (hasCookie('trkCode=bf')) {
-    return detectByCookies('linkedin')
+    return byCookies('linkedin')
   }
 
   // YouTube: empty title pattern indicates a degraded response requiring BotGuard JS attestation
   // Normal pages have `<title>Video Title - YouTube</title>`, bots get `<title> - YouTube</title>`
   if (htmlHas('<title>\\s*-\\s*YouTube<\\/title>', true)) {
-    return detectByHtml('youtube')
+    return byHtml('youtube')
   }
 
   // AWS WAF: Check for x-amzn-waf-action or x-amzn-requestid headers
   // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-aws-waf.json
-  if (getHeader('x-amzn-waf-action') || getHeader('x-amzn-requestid')) {
-    return detectByHeaders('aws-waf')
+  if (hasAnyHeader(['x-amzn-waf-action', 'x-amzn-requestid'])) {
+    return byHeaders('aws-waf')
   }
 
   // AWS WAF: Check for aws-waf or awswaf text in html
-  if (htmlHas('aws-waf') || htmlHas('awswaf')) {
-    return detectByHtml('aws-waf')
+  if (hasAnyHtml(['aws-waf', 'awswaf'])) {
+    return byHtml('aws-waf')
   }
 
   // AWS WAF: aws-waf-token cookie
   if (hasCookie('aws-waf-token=')) {
-    return detectByCookies('aws-waf')
+    return byCookies('aws-waf')
   }
 
   return createResult(false, null, null)

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ test('cloudflare (cf-mitigated header)', t => {
   const result = isAntibot({ headers })
   t.is(result.detected, true)
   t.is(result.provider, 'cloudflare')
+  t.is(result.technique, 'headers')
 })
 
 test('cloudflare (cf_clearance set-cookie)', t => {
@@ -16,6 +17,7 @@ test('cloudflare (cf_clearance set-cookie)', t => {
   const result = isAntibot({ headers })
   t.is(result.detected, true)
   t.is(result.provider, 'cloudflare')
+  t.is(result.technique, 'cookies')
 })
 
 test('vercel', t => {
@@ -58,6 +60,7 @@ test('akamai (no antibot)', t => {
   const result = isAntibot({ headers })
   t.is(result.detected, false)
   t.is(result.provider, null)
+  t.is(result.technique, null)
 })
 
 test('datadome (x-dd-b header)', t => {
@@ -221,6 +224,7 @@ test('reblaze (html)', t => {
   const result = isAntibot({ html })
   t.is(result.detected, true)
   t.is(result.provider, 'reblaze')
+  t.is(result.technique, 'html')
 })
 
 test('cheq (html CheqSdk)', t => {
@@ -242,6 +246,7 @@ test('cheq (url cheqzone.com)', t => {
   const result = isAntibot({ url })
   t.is(result.detected, true)
   t.is(result.provider, 'cheq')
+  t.is(result.technique, 'url')
 })
 
 test('cheq (url cheq.ai)', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ test('cloudflare (cf-mitigated header)', t => {
   const result = isAntibot({ headers })
   t.is(result.detected, true)
   t.is(result.provider, 'cloudflare')
-  t.is(result.technique, 'headers')
+  t.is(result.detection, 'headers')
 })
 
 test('cloudflare (cf_clearance set-cookie)', t => {
@@ -17,7 +17,7 @@ test('cloudflare (cf_clearance set-cookie)', t => {
   const result = isAntibot({ headers })
   t.is(result.detected, true)
   t.is(result.provider, 'cloudflare')
-  t.is(result.technique, 'cookies')
+  t.is(result.detection, 'cookies')
 })
 
 test('vercel', t => {
@@ -60,7 +60,7 @@ test('akamai (no antibot)', t => {
   const result = isAntibot({ headers })
   t.is(result.detected, false)
   t.is(result.provider, null)
-  t.is(result.technique, null)
+  t.is(result.detection, null)
 })
 
 test('datadome (x-dd-b header)', t => {
@@ -224,7 +224,7 @@ test('reblaze (html)', t => {
   const result = isAntibot({ html })
   t.is(result.detected, true)
   t.is(result.provider, 'reblaze')
-  t.is(result.technique, 'html')
+  t.is(result.detection, 'html')
 })
 
 test('cheq (html CheqSdk)', t => {
@@ -246,7 +246,7 @@ test('cheq (url cheqzone.com)', t => {
   const result = isAntibot({ url })
   t.is(result.detected, true)
   t.is(result.provider, 'cheq')
-  t.is(result.technique, 'url')
+  t.is(result.detection, 'url')
 })
 
 test('cheq (url cheq.ai)', t => {

--- a/test/interface.js
+++ b/test/interface.js
@@ -11,20 +11,20 @@ const headers = { 'user-agent': 'curl/7.81.0' }
 test('from fetch', async t => {
   const response = await fetch(url, { headers })
   const html = await response.text()
-  const { detected, provider, technique } = isAntibot({
+  const { detected, provider, detection } = isAntibot({
     headers: response.headers,
     html,
     url: response.url
   })
   t.is(detected, true)
   t.is(provider, 'linkedin')
-  t.true(['headers', 'cookies', 'html', 'url'].includes(technique))
+  t.true(['headers', 'cookies', 'html', 'url'].includes(detection))
 })
 
 test('from got', async t => {
   const response = await got(url, { headers }).catch(error => error.response)
-  const { detected, provider, technique } = isAntibot(response)
+  const { detected, provider, detection } = isAntibot(response)
   t.is(detected, true)
   t.is(provider, 'linkedin')
-  t.true(['headers', 'cookies', 'html', 'url'].includes(technique))
+  t.true(['headers', 'cookies', 'html', 'url'].includes(detection))
 })

--- a/test/interface.js
+++ b/test/interface.js
@@ -11,18 +11,20 @@ const headers = { 'user-agent': 'curl/7.81.0' }
 test('from fetch', async t => {
   const response = await fetch(url, { headers })
   const html = await response.text()
-  const { detected, provider } = isAntibot({
+  const { detected, provider, technique } = isAntibot({
     headers: response.headers,
     html,
     url: response.url
   })
   t.is(detected, true)
   t.is(provider, 'linkedin')
+  t.true(['headers', 'cookies', 'html', 'url'].includes(technique))
 })
 
 test('from got', async t => {
   const response = await got(url, { headers }).catch(error => error.response)
-  const { detected, provider } = isAntibot(response)
+  const { detected, provider, technique } = isAntibot(response)
   t.is(detected, true)
   t.is(provider, 'linkedin')
+  t.true(['headers', 'cookies', 'html', 'url'].includes(technique))
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `detection` field to the public API and refactors matching logic to use mixed string/RegExp patterns, which could subtly change detection behavior for some providers despite test updates.
> 
> **Overview**
> **Adds reporting of where antibot detection came from.** `isAntibot` now returns `{ detected, provider, detection }`, where `detection` indicates whether the match was found via *headers*, *cookies*, *html*, or *url*.
> 
> Internally, detection rules are refactored to use helper functions (`hasAnyHeader`/`hasAnyCookie`/`hasAnyHtml`/`hasAnyUrl`) and to support passing `RegExp` objects directly to pattern checks; docs and tests are updated to assert the new `detection` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19fafe2e6a2c1e245f8c55ceace2e18cbec3027f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->