### PR TITLE
fix: x-datadome as protected is not enough

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,9 +125,15 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
     return byHeaders('datadome')
   }
 
-  // DataDome: Check for x-datadome or x-datadome-cid header presence
-  // Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-datadome.json
-  if (hasAnyHeader(['x-datadome', 'x-datadome-cid'])) {
+  // DataDome: x-datadome header presence.
+  // Note: `x-datadome: protected` can appear on successful responses.
+  const xDatadome = getHeader('x-datadome')
+  if (xDatadome && String(xDatadome).toLowerCase() !== 'protected') {
+    return byHeaders('datadome')
+  }
+
+  // DataDome: x-datadome-cid header presence
+  if (hasAnyHeader(['x-datadome-cid'])) {
     return byHeaders('datadome')
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -79,6 +79,13 @@ test('datadome (x-datadome header)', t => {
   t.is(result.provider, 'datadome')
 })
 
+test('datadome (x-datadome protected is not enough)', t => {
+  const headers = { 'x-datadome': 'protected' }
+  const result = isAntibot({ headers })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
+})
+
 test('datadome (x-datadome-cid header)', t => {
   const headers = { 'x-datadome-cid': 'abc123' }
   const result = isAntibot({ headers })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core detection heuristics for DataDome and could alter detection outcomes (reducing false positives but potentially missing edge cases). Scope is small and covered by an added regression test.
> 
> **Overview**
> Adjusts DataDome header-based detection so `x-datadome` only triggers when present with a value other than `protected`, and keeps `x-datadome-cid` as a separate positive signal.
> 
> Adds a regression test ensuring `x-datadome: protected` alone does *not* mark a response as antibot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9037a1ce5152cdcad311af608e46f4fe4255cd59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->