### PR TITLE
feat: reddit detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - **Ocule** - Bot detection with advanced obfuscation
 - **YouTube** - BotGuard attestation and abuse detection
 - **LinkedIn** - Bot filter protection
+- **Reddit** - Network security challenge-page detection
 
 ### CAPTCHA Providers
 
@@ -45,7 +46,7 @@
 
 ## Why
 
-Websites receiving massive quantities of traffic throughout the day, like LinkedIn, Instagram, or YouTube, have sophisticated antibot systems to prevent automated access.
+Websites receiving massive quantities of traffic throughout the day, like LinkedIn, Reddit, Instagram, or YouTube, have sophisticated antibot systems to prevent automated access.
 
 When you try to fetch the HTML of these sites without the right tools, you often hit a 403 Forbidden, 429 Too Many Requests, or a "Please prove you're human" challenge, leaving you with a response that contains no useful data.
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "waf"
   ],
   "dependencies": {
+    "@metascraper/helpers": "~5.50.0",
     "cookie-es": "~3.1.1",
     "debug-logfmt": "~1.4.7"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { splitSetCookieString } = require('cookie-es')
+const { parseUrl } = require('@metascraper/helpers')
 const debug = require('debug-logfmt')('is-antibot')
 
 const DETECTION = {
@@ -385,6 +386,15 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   // AliExpress CAPTCHA: Check for x5secdata in html
   if (hasAnyHtml(['x5secdata'])) {
     return byHtml('aliexpress-captcha')
+  }
+
+  // Reddit: blocked requests are served as HTML challenge pages.
+  // Strongest signal is the blocked-page copy in HTML.
+  if (
+    parseUrl(url).domain === 'reddit.com' &&
+    hasAnyHtml([/blocked by network security\./i])
+  ) {
+    return byHtml('reddit')
   }
 
   // LinkedIn: trkCode=bf cookie ("bot filter") is set when LinkedIn blocks a request

--- a/test/index.js
+++ b/test/index.js
@@ -550,6 +550,36 @@ test('aliexpress-captcha (html)', t => {
   t.is(result.provider, 'aliexpress-captcha')
 })
 
+test('reddit (blocked html)', t => {
+  const html = '<div>blocked by network security.</div>'
+  const url =
+    'https://www.reddit.com/r/lotus/comments/1pzbv0z/my_lotus_elise_72d_with_17_rays_volk_gtp/'
+  const result = isAntibot({ html, url })
+  t.is(result.detected, true)
+  t.is(result.provider, 'reddit')
+  t.is(result.detection, 'html')
+})
+
+test('reddit (blocked html on non-reddit url should not match)', t => {
+  const html = '<div>blocked by network security.</div>'
+  const url = 'https://example.com/some/path'
+  const result = isAntibot({ html, url })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
+})
+
+test('reddit (allowed endpoint)', t => {
+  const headers = {
+    'content-type': 'application/json; charset=UTF-8',
+    server: 'snooserv'
+  }
+  const url =
+    'https://www.reddit.com/r/lotus/comments/1pzbv0z/my_lotus_elise_72d_with_17_rays_volk_gtp/'
+  const result = isAntibot({ headers, url })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
+})
+
 test('linkedin (got set-cookie as array)', t => {
   const headers = {
     'set-cookie': [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new detection logic that parses URLs and adds a new runtime dependency, which could cause false positives/negatives or edge-case failures on malformed URLs. Scope is otherwise small and covered by added tests.
> 
> **Overview**
> **Adds Reddit support** to `is-antibot` by detecting Reddit "blocked by network security." challenge HTML *only when* the request URL resolves to `reddit.com`.
> 
> Updates docs to list Reddit as a supported provider, adds `@metascraper/helpers` for URL domain parsing, and expands the test suite with positive and negative Reddit cases (including a non-Reddit false-positive guard).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 281312d86e9770887aebfdbc621fb5a175d0ac78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->