### PR TITLE
feat: add status code detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ npm install is-antibot --save
 
 ## Usage
 
-Just pass `headers`, `html`, and `url` from any HTTP response:
+Just pass `headers`, `html`, `url`, and `statusCode` from any HTTP response:
 
 ```js
 const isAntibot = require('is-antibot')
@@ -70,6 +70,7 @@ const html = await response.text()
 
 const { detected, provider, detection } = isAntibot({
   headers: response.headers,
+  statusCode: response.status,
   html,
   url: response.url
 })
@@ -96,7 +97,7 @@ The library returns an object with the following properties:
 
 - `detected` (boolean): Whether an antibot challenge was detected
 - `provider` (string|null): The name of the detected provider (e.g., 'cloudflare', 'recaptcha')
-- `detection` (string|null): Where the signal came from: `'headers'`, `'cookies'`, `'html'`, or `'url'`
+- `detection` (string|null): Where the signal came from: `'headers'`, `'cookies'`, `'html'`, `'url'`, or `'statusCode'`
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ const DETECTION = {
   HEADERS: 'headers',
   COOKIES: 'cookies',
   HTML: 'html',
-  URL: 'url'
+  URL: 'url',
+  STATUS_CODE: 'statusCode'
 }
 
 const createGetHeader = headers =>
@@ -57,7 +58,7 @@ const getHeaderNames = headers =>
     ? Array.from(headers.keys())
     : Object.keys(headers)
 
-const detect = ({ headers = {}, html = '', url = '' } = {}) => {
+const detect = ({ headers = {}, html = '', url = '', statusCode } = {}) => {
   const getHeader = createGetHeader(headers)
   const hasCookie = createHasCookie(headers)
   const htmlHas = createTestPattern(html)
@@ -80,6 +81,9 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
   const byHtml = provider => createResult(true, provider, DETECTION.HTML)
 
   const byUrl = provider => createResult(true, provider, DETECTION.URL)
+
+  const byStatusCode = provider =>
+    createResult(true, provider, DETECTION.STATUS_CODE)
 
   // CloudFlare: Check for cf-mitigated header with 'challenge' value
   // Official docs: https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/
@@ -397,9 +401,9 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
     return byHtml('reddit')
   }
 
-  // LinkedIn: trkCode=bf cookie ("bot filter") is set when LinkedIn blocks a request
-  if (hasAnyCookie(['trkCode=bf'])) {
-    return byCookies('linkedin')
+  // LinkedIn: status 999 is LinkedIn's dedicated bot-detection response
+  if (parseUrl(url).domain === 'linkedin.com' && statusCode === 999) {
+    return byStatusCode('linkedin')
   }
 
   // YouTube: empty title pattern indicates a degraded response requiring BotGuard JS attestation
@@ -428,8 +432,13 @@ const detect = ({ headers = {}, html = '', url = '' } = {}) => {
 }
 
 const isAntibot = (input = {}) => {
-  const { headers, html, body, url } = input
-  return detect({ headers, html: html || body, url })
+  const { headers, html, body, url, statusCode, status } = input
+  return detect({
+    headers,
+    html: html || body,
+    url,
+    statusCode: statusCode ?? status
+  })
 }
 
 module.exports = isAntibot

--- a/test/index.js
+++ b/test/index.js
@@ -580,36 +580,28 @@ test('reddit (allowed endpoint)', t => {
   t.is(result.provider, null)
 })
 
-test('linkedin (got set-cookie as array)', t => {
-  const headers = {
-    'set-cookie': [
-      'trkCode=bf; Max-Age=5',
-      'trkInfo=AQFAratONFrB2AAAAZ0pYgFwkRxy7pe2KqithoZ4DrIdVyCD8WiY3gYONBobD4g7t-PWmVWJzN28GTO7ZeKfrcPmTti_uaSFN-8qXScyFz-hE-pBpGPZuyIRSsqcCtg0OsMdUX4=; Max-Age=5',
-      'rtc=AQEVeAM-pHq_2QAAAZ0pYgFw6by_4L6d1QzyV8pieP39_RzmN8vtczqYcGa2WGH5LwJWuR0JT_GsVzsuuEOaQtWxSNnLIC9ARJF3qu-Ym5hkaxkL5Ciaa-WN264N2_xsawkGjX-snaZ4Nx0GGWEZlPzoNaX_ODWeNpbln_P6yWOykLOwSxcWtPLlGKRV8g4iubY9Rr0GiFUhTSsNXgxnOFfqnXA=; Max-Age=120; path=/; domain=.linkedin.com',
-      '__cf_bm=SMqN8mDteTetWk0K04HDlr8GBw_7.aINZ4GPOztm3H8-1774515782-1.0.1.1-ei2drbbibbsB.7gExLK7sOcjkxwFxQA.4tWMyU0isXPg8lzPuBGYKIb94wx9uKBfHQWb0eNRKOlTZKb.KE227rK9Vje15fD3gYHFG2bpnvA; path=/; expires=Thu, 26-Mar-26 09:33:02 GMT; domain=.linkedin.com; HttpOnly; Secure; SameSite=None'
-    ]
-  }
-  const result = isAntibot({ headers })
+test('linkedin (status 999)', t => {
+  const result = isAntibot({
+    statusCode: 999,
+    url: 'https://www.linkedin.com/in/wesbos'
+  })
   t.is(result.detected, true)
   t.is(result.provider, 'linkedin')
+  t.is(result.detection, 'statusCode')
 })
 
-test('linkedin (fetch set-cookie as comma-joined string)', t => {
-  const headers = {
-    'set-cookie':
-      'trkCode=bf; Max-Age=5, trkInfo=AQFyonFtUZqc7AAAAZ0pYrzwPDR4VFZ_9p6fG0FvEcRgl8OPYOi_BuI0UjU5CWQ8ajOcRDP94FWd1WG6ml4bCIeTNo529UZFwMB_Pit8kSdbz5IzaPaVV0VLYrO1HwPhyu2APN4=; Max-Age=5, rtc=AQEwoUg34YjbqQAAAZ0pYrzwk3vgeorXn_hlwqY4LaH634gq_kHjFzZC_qrYXquN4zzqX50dVT8cqdcMbfyhAdu3RA6gjC6glMQah0nh9lEeiircCG43N6-oCN4kObfwug1PtZ619Yl0F3MK-TSvU3h3KYyvW4vltvXhLrxeK9DpT5AjGyD0WDPrM8KtK7w7UF9SEsTBYrpyPqcm6nfvrYY6QY0=; Max-Age=120; path=/; domain=.linkedin.com, __cf_bm=TBitBBkee9M2KOZkThR1uXuERq5RTmOKtLwnU7KxQYM-1774515830-1.0.1.1-09U1TNumW0aJGTQClLtEJRVB92lnaY0_IVz4X6E_Vulp2cS1VcnqhX81f28bwKLxPfIZ.lrkhjKn.yNK_Impgkj3QjDocla2r5PETU_QN0A; path=/; expires=Thu, 26-Mar-26 09:33:50 GMT; domain=.linkedin.com; HttpOnly; Secure; SameSite=None'
-  }
-  const result = isAntibot({ headers })
-  t.is(result.detected, true)
-  t.is(result.provider, 'linkedin')
+test('linkedin (status 999 ignored for non-linkedin url)', t => {
+  const result = isAntibot({ statusCode: 999, url: 'https://example.com' })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
 })
 
-test('linkedin (no antibot without trkCode=bf)', t => {
+test('linkedin (no antibot without status 999)', t => {
   const headers = {
     'x-li-fabric': 'prod-lor1',
     'set-cookie': 'other=value; Max-Age=5'
   }
-  const result = isAntibot({ headers })
+  const result = isAntibot({ headers, statusCode: 200 })
   t.is(result.detected, false)
   t.is(result.provider, null)
 })

--- a/test/interface.js
+++ b/test/interface.js
@@ -13,12 +13,15 @@ test('from fetch', async t => {
   const html = await response.text()
   const { detected, provider, detection } = isAntibot({
     headers: response.headers,
+    statusCode: response.status,
     html,
     url: response.url
   })
   t.is(detected, true)
   t.is(provider, 'linkedin')
-  t.true(['headers', 'cookies', 'html', 'url'].includes(detection))
+  t.true(
+    ['headers', 'cookies', 'html', 'url', 'statusCode'].includes(detection)
+  )
 })
 
 test('from got', async t => {
@@ -26,5 +29,7 @@ test('from got', async t => {
   const { detected, provider, detection } = isAntibot(response)
   t.is(detected, true)
   t.is(provider, 'linkedin')
-  t.true(['headers', 'cookies', 'html', 'url'].includes(detection))
+  t.true(
+    ['headers', 'cookies', 'html', 'url', 'statusCode'].includes(detection)
+  )
 })

--- a/test/util.js
+++ b/test/util.js
@@ -25,6 +25,7 @@ const loadFixture = async filepath => {
   const response = json.log.entries[0].response
   return {
     headers: headersFromHAR(response),
+    statusCode: response.status,
     html: response.content?.text || '',
     url: json.log.entries[0].request?.url || ''
   }
@@ -32,13 +33,16 @@ const loadFixture = async filepath => {
 
 const PROVIDER_FIXTURES = readdirSync(PROVIDERS_PATH)
   .filter(file => statSync(path.join(PROVIDERS_PATH, file)).isDirectory())
-  .reduce((acc, name) => {
-    const dir = path.join(PROVIDERS_PATH, name)
-    const failed = path.join(dir, 'failed.json')
-    const success = path.join(dir, 'success.json')
-    if (existsSync(failed)) acc.failed.push({ name, path: failed })
-    if (existsSync(success)) acc.success.push({ name, path: success })
-    return acc
-  }, { failed: [], success: [] })
+  .reduce(
+    (acc, name) => {
+      const dir = path.join(PROVIDERS_PATH, name)
+      const failed = path.join(dir, 'failed.json')
+      const success = path.join(dir, 'success.json')
+      if (existsSync(failed)) acc.failed.push({ name, path: failed })
+      if (existsSync(success)) acc.success.push({ name, path: success })
+      return acc
+    },
+    { failed: [], success: [] }
+  )
 
 module.exports = { PROVIDER_FIXTURES, loadFixture }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the public input shape (adds `statusCode`/`status` handling) and alters LinkedIn detection behavior from cookie-based to HTTP status-based, which could affect existing consumers’ detection results.
> 
> **Overview**
> Adds optional `statusCode`/`status` support to `isAntibot` and threads it through detection results via a new `detection: 'statusCode'` signal.
> 
> Updates LinkedIn detection to trigger specifically on `linkedin.com` responses with HTTP status `999` (replacing the prior `trkCode=bf` cookie heuristic), and revises docs/tests/fixtures loading to supply and assert `statusCode` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c18925927372caa5e3748efc5c1a23d664fa075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->