### PR TITLE
chore: add instagram login detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,18 +20,10 @@ const createGetHeader = headers =>
 const createTestPattern = value => {
   if (!value) return () => false
   const lowerValue = value.toLowerCase()
-  return (pattern, isRegex = false) => {
+  return pattern => {
     if (pattern instanceof RegExp) {
       try {
         return pattern.test(value)
-      } catch {
-        return false
-      }
-    }
-
-    if (isRegex) {
-      try {
-        return new RegExp(pattern, 'i').test(value)
       } catch {
         return false
       }
@@ -404,6 +396,14 @@ const detect = ({ headers = {}, html = '', url = '', statusCode } = {}) => {
   // LinkedIn: status 999 is LinkedIn's dedicated bot-detection response
   if (parseUrl(url).domain === 'linkedin.com' && statusCode === 999) {
     return byStatusCode('linkedin')
+  }
+
+  // Instagram: login page redirect indicates bot detection
+  if (
+    parseUrl(url).domain === 'instagram.com' &&
+    hasAnyHtml([/<title>\s*Login\s*[•·]\s*Instagram\s*<\/title>/i])
+  ) {
+    return byHtml('instagram')
   }
 
   // YouTube: empty title pattern indicates a degraded response requiring BotGuard JS attestation

--- a/test/index.js
+++ b/test/index.js
@@ -606,6 +606,18 @@ test('linkedin (no antibot without status 999)', t => {
   t.is(result.provider, null)
 })
 
+test('instagram (login page redirect)', t => {
+  const html =
+    '<!DOCTYPE html><html lang="en"><head><title>Login \u2022 Instagram</title></head><body></body></html>'
+  const result = isAntibot({
+    html,
+    url: 'https://www.instagram.com/kikobeats/'
+  })
+  t.is(result.detected, true)
+  t.is(result.provider, 'instagram')
+  t.is(result.detection, 'html')
+})
+
 test('youtube (empty title in html)', t => {
   const html =
     '<!DOCTYPE html><html><head><title> - YouTube</title></head><body><ytd-app disable-upgrade="true"></ytd-app></body></html>'
@@ -653,7 +665,7 @@ test('aws-waf (aws-waf-token set-cookie)', t => {
 test('createTestPattern with invalid regex catches error', t => {
   const { createTestPattern } = require('../src')
   const has = createTestPattern('test')
-  t.is(has('[invalid(regex', true), false)
+  t.is(has('[invalid(regex'), false)
 })
 
 test('testPattern with invalid regex', t => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new Instagram HTML-based detection and changes `createTestPattern` behavior by dropping string-regex support, which could affect any consumers relying on the old `isRegex` parameter.
> 
> **Overview**
> Adds Instagram bot-detection by flagging `instagram.com` responses whose HTML title matches the Instagram login page, returning an `html`-based detection.
> 
> Simplifies `createTestPattern` to only support `RegExp` objects and case-insensitive substring matching, removing the prior `isRegex` path for compiling regexes from strings; tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ee7535072be975e2d3db138f03a4e223465783e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->