### PR TITLE
chore: 403 reddit detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -385,12 +385,13 @@ const detect = ({ headers = {}, html = '', url = '', statusCode } = {}) => {
   }
 
   // Reddit: blocked requests are served as HTML challenge pages.
-  // Strongest signal is the blocked-page copy in HTML.
-  if (
-    parseUrl(url).domain === 'reddit.com' &&
-    hasAnyHtml([/blocked by network security\./i])
-  ) {
-    return byHtml('reddit')
+  if (parseUrl(url).domain === 'reddit.com') {
+    if (statusCode === 403) {
+      return byStatusCode('reddit')
+    }
+    if (hasAnyHtml([/blocked by network security\./i])) {
+      return byHtml('reddit')
+    }
   }
 
   // LinkedIn: status 999 is LinkedIn's dedicated bot-detection response

--- a/test/index.js
+++ b/test/index.js
@@ -568,6 +568,20 @@ test('reddit (blocked html on non-reddit url should not match)', t => {
   t.is(result.provider, null)
 })
 
+test('reddit (blocked by status code)', t => {
+  const headers = {
+    'content-type': 'text/html',
+    server: 'snooserv',
+    'cache-control': 'private, no-store'
+  }
+  const url =
+    'https://www.reddit.com/r/digitalnomad/comments/1riz2r5/i_love_mexico_city_but_i_feel_so_unhealthy_here/'
+  const result = isAntibot({ headers, url, statusCode: 403 })
+  t.is(result.detected, true)
+  t.is(result.provider, 'reddit')
+  t.is(result.detection, 'statusCode')
+})
+
 test('reddit (allowed endpoint)', t => {
   const headers = {
     'content-type': 'application/json; charset=UTF-8',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, localized change, but it may increase false positives by treating any `reddit.com` 403 as an antibot event even when the request is legitimately forbidden.
> 
> **Overview**
> Extends Reddit antibot detection to treat `reddit.com` responses with HTTP `403` as blocked, in addition to the existing HTML-based "blocked by network security" check.
> 
> Adds a unit test asserting `statusCode: 403` yields a `reddit` detection via `statusCode` while keeping the non-Reddit HTML false-positive guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d0e456e68994e0676afa5ad5d74bd856aef3107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->