### PR TITLE
ci: migrate GitHub Actions workflows to Python/uv

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,63 +6,32 @@ on:
       - master
 
 jobs:
-  contributors:
-    if: "${{ github.event.head_commit.message != 'build: contributors' }}"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-      - name: Contributors
-        run: |
-          git config --global user.email ${{ secrets.GIT_EMAIL }}
-          git config --global user.name ${{ secrets.GIT_USERNAME }}
-          npm run contributors
-      - name: Push changes
-        run: |
-          git push origin ${{ github.head_ref }}
-
   release:
     if: |
       !startsWith(github.event.head_commit.message, 'chore(release):') &&
       !startsWith(github.event.head_commit.message, 'docs:') &&
       !startsWith(github.event.head_commit.message, 'ci:')
-    needs: [contributors]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v5
-        with:
-          version: latest
-          run_install: true
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Set up Python
+        run: uv python install 3.13
+      - name: Install dependencies
+        run: uv sync
       - name: Test
-        run: pnpm test
-      - name: Report
-        run: npx c8 report --reporter=text-lcov > coverage/lcov.info
+        run: uv run pytest -v --cov=is_antibot --cov-report=lcov:coverage/lcov.info
       - name: Coverage
         uses: coverallsapp/github-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Release
+      - name: Build
+        run: uv build
+      - name: Publish to PyPI
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          git config --global user.email ${{ secrets.GIT_EMAIL }}
-          git config --global user.name ${{ secrets.GIT_USERNAME }}
-          git pull origin master
-          pnpm run release
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: uv publish

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,24 +12,21 @@ jobs:
   test:
     if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v5
-        with:
-          version: latest
-          run_install: true
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync
+      - name: Lint
+        run: uv run ruff check src/ tests/
       - name: Test
-        run: pnpm test
-      - name: Report
-        run: npx c8 report --reporter=text-lcov > coverage/lcov.info
+        run: uv run pytest -v --cov=is_antibot --cov-report=lcov:coverage/lcov.info
       - name: Coverage
         uses: coverallsapp/github-action@main
         with:


### PR DESCRIPTION
## Summary
- Replace Node.js/pnpm CI/CD pipeline with Python/uv equivalents
- Use `astral-sh/setup-uv` for uv installation and `pytest` for testing
- Add ruff linting step and Python 3.10-3.13 test matrix in PR workflow
- Publish to PyPI instead of npm in release workflow

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Verify workflow runs correctly on a test push

🤖 Generated with [Claude Code](https://claude.com/claude-code)