### PR TITLE
feat: migrate is-antibot library to Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,80 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "is-antibot"
+version = "1.7.1"
+description = "Detect antibot protection from 30+ providers — Cloudflare, Akamai, DataDome, PerimeterX, Kasada, Imperva, reCAPTCHA, hCaptcha, Turnstile, and more."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+authors = [{ name = "Microlink", email = "hello@microlink.io" }]
+keywords = [
+    "akamai",
+    "antibot",
+    "anubis",
+    "arkose",
+    "aws-waf",
+    "bot",
+    "bot-detection",
+    "bot-protection",
+    "captcha",
+    "challenge",
+    "cloudflare",
+    "datadome",
+    "detection",
+    "friendly-captcha",
+    "funcaptcha",
+    "geetest",
+    "hcaptcha",
+    "imperva",
+    "incapsula",
+    "kasada",
+    "perimeterx",
+    "reblaze",
+    "recaptcha",
+    "scraper",
+    "scraping",
+    "shapesecurity",
+    "sucuri",
+    "turnstile",
+    "vercel",
+    "waf",
+    "web-scraping",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.urls]
+Homepage = "https://antibot.microlink.io/"
+Repository = "https://github.com/microlinkhq/is-antibot"
+Issues = "https://github.com/microlinkhq/is-antibot/issues"
+
+[dependency-groups]
+dev = [{ include-group = "lint" }, { include-group = "test" }]
+lint = ["ruff"]
+test = ["pytest", "pytest-cov", "httpx"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/is_antibot"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/is_antibot/__init__.py
+++ b/src/is_antibot/__init__.py
@@ -1,0 +1,539 @@
+"""Detect antibot protection from 30+ providers."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+logger = logging.getLogger("is_antibot")
+
+# Detection type constants
+_HEADERS = "headers"
+_COOKIES = "cookies"
+_HTML = "html"
+_URL = "url"
+_STATUS_CODE = "status_code"
+
+
+@dataclass(frozen=True)
+class AntibotResult:
+    """Result of antibot detection."""
+
+    detected: bool
+    provider: str | None
+    detection: str | None
+
+
+def _create_get_header(headers: Mapping[str, str | list[str] | None]):
+    """Create a header getter function."""
+    return lambda name: headers.get(name)
+
+
+def create_test_pattern(value: str | None):
+    """Create a pattern checker for the given value.
+
+    Returns a function that checks whether a pattern (regex or string)
+    matches the given value.
+    """
+    if not value:
+        return lambda pattern: False
+    lower_value = value.lower()
+
+    def test(pattern: re.Pattern[str] | str) -> bool:
+        if isinstance(pattern, re.Pattern):
+            try:
+                return pattern.search(value) is not None
+            except Exception:
+                return False
+        return pattern.lower() in lower_value
+
+    return test
+
+
+def _split_set_cookie_string(cookie_str: str | list[str] | None) -> list[str]:
+    """Split a Set-Cookie header string into individual cookie strings.
+
+    Handles comma-separated cookies while correctly preserving commas in
+    Expires date values. Port of the cookie-es splitSetCookieString algorithm.
+    """
+    if cookie_str is None:
+        return []
+    if isinstance(cookie_str, list):
+        return cookie_str
+    if not cookie_str:
+        return []
+
+    cookies: list[str] = []
+    pos = 0
+    start = 0
+    length = len(cookie_str)
+
+    while pos < length:
+        # Scan for the next comma
+        while pos < length and cookie_str[pos] != ",":
+            pos += 1
+
+        if pos >= length:
+            break
+
+        # Found a comma at pos. Look ahead to see if next token is a cookie name (has '=')
+        lookahead = pos + 1
+        # skip whitespace
+        while lookahead < length and cookie_str[lookahead] == " ":
+            lookahead += 1
+
+        # Find next '=' or ';' to determine if this starts a new cookie
+        scan = lookahead
+        is_new_cookie = False
+        while scan < length:
+            ch = cookie_str[scan]
+            if ch == "=":
+                is_new_cookie = True
+                break
+            if ch == ";" or ch == ",":
+                break
+            scan += 1
+
+        if is_new_cookie:
+            # This comma separates two cookies
+            cookies.append(cookie_str[start:pos].strip())
+            start = pos + 1
+            # skip whitespace after comma
+            while start < length and cookie_str[start] == " ":
+                start += 1
+            pos = start
+        else:
+            # Comma is part of a date value (e.g., "Thu, 26-Mar-26 ...")
+            pos += 1
+
+    # Append the remaining segment
+    remaining = cookie_str[start:].strip()
+    if remaining:
+        cookies.append(remaining)
+
+    return cookies
+
+
+def create_has_cookie(headers: Mapping[str, str | list[str] | None]):
+    """Create a function that checks for cookie presence in Set-Cookie headers.
+
+    Returns a function that takes a cookie prefix pattern and returns True if
+    any Set-Cookie value starts with that pattern.
+    """
+    cookies = _split_set_cookie_string(headers.get("set-cookie"))
+
+    def has_cookie(pattern: str) -> bool:
+        return any(c.startswith(pattern) for c in cookies)
+
+    return has_cookie
+
+
+def _get_header_names(headers: Mapping[str, str | list[str] | None]) -> list[str]:
+    """Return all header names as a list."""
+    return list(headers.keys())
+
+
+def _get_domain(url: str) -> str:
+    """Extract the registrable domain from a URL (e.g. 'www.reddit.com' -> 'reddit.com')."""
+    hostname = urlparse(url).hostname or ""
+    parts = hostname.split(".")
+    if len(parts) >= 2:
+        return ".".join(parts[-2:])
+    return hostname
+
+
+# Pre-compiled regex patterns
+_RE_SHAPE_HEADER = re.compile(r"^x-[a-z0-9]{8}-[abcdfz]$", re.IGNORECASE)
+_RE_CHEQZONE = re.compile(r"cheqzone\.com", re.IGNORECASE)
+_RE_CHEQ_AI = re.compile(r"cheq\.ai", re.IGNORECASE)
+_RE_MEETRICS = re.compile(r"meetrics\.com", re.IGNORECASE)
+_RE_OCULE = re.compile(r"ocule\.co\.uk", re.IGNORECASE)
+_RE_GOOGLE_RECAPTCHA = re.compile(r"google\.com/recaptcha", re.IGNORECASE)
+_RE_GRECAPTCHA_API = re.compile(
+    r"\b(?:window\.)?grecaptcha\s*\.(?:execute|render|ready|getResponse|enterprise)\b", re.IGNORECASE
+)
+_RE_GRECAPTCHA_CALL = re.compile(r"\b(?:window\.)?grecaptcha\s*\(", re.IGNORECASE)
+_RE_GRECAPTCHA_CFG = re.compile(r"\b__grecaptcha_cfg\b", re.IGNORECASE)
+_RE_HCAPTCHA = re.compile(r"hcaptcha\.com", re.IGNORECASE)
+_RE_ARKOSELABS = re.compile(r"arkoselabs\.com", re.IGNORECASE)
+_RE_GEETEST = re.compile(r"geetest\.com", re.IGNORECASE)
+_RE_CF_TURNSTILE = re.compile(r"challenges\.cloudflare\.com/turnstile", re.IGNORECASE)
+_RE_FRIENDLY_CAPTCHA = re.compile(r"friendlycaptcha\.com", re.IGNORECASE)
+_RE_CAPTCHA_EU = re.compile(r"captcha\.eu", re.IGNORECASE)
+_RE_QCLOUD = re.compile(r"turing\.captcha\.qcloud\.com", re.IGNORECASE)
+_RE_ALIEXPRESS = re.compile(r"punish\?x5secdata", re.IGNORECASE)
+_RE_REDDIT_BLOCKED = re.compile(r"blocked by network security\.", re.IGNORECASE)
+_RE_INSTAGRAM_LOGIN = re.compile(r"<title>\s*Login\s*[•·]\s*Instagram\s*</title>", re.IGNORECASE)
+_RE_YOUTUBE_EMPTY = re.compile(r"<title>\s*-\s*YouTube</title>", re.IGNORECASE)
+_RE_ANUBIS_SCRIPT = re.compile(r'<script id="anubis_challenge"')
+
+
+def _detect(
+    headers: Mapping[str, str | list[str] | None],
+    html: str,
+    url: str,
+    status_code: int | None,
+) -> AntibotResult:
+    """Run the full detection chain. Returns on first match."""
+    get_header = _create_get_header(headers)
+    has_cookie = create_has_cookie(headers)
+    html_has = create_test_pattern(html)
+    url_has = create_test_pattern(url)
+
+    def has_any_header(header_names: list[str]) -> bool:
+        return any(get_header(name) for name in header_names)
+
+    def has_any_cookie(cookie_names: list[str]) -> bool:
+        return any(has_cookie(name) for name in cookie_names)
+
+    def has_any_html(patterns: list[re.Pattern[str] | str]) -> bool:
+        return any(html_has(p) for p in patterns)
+
+    def has_any_url(patterns: list[re.Pattern[str] | str]) -> bool:
+        return any(url_has(p) for p in patterns)
+
+    def by_headers(provider: str) -> AntibotResult:
+        return _create_result(True, provider, _HEADERS)
+
+    def by_cookies(provider: str) -> AntibotResult:
+        return _create_result(True, provider, _COOKIES)
+
+    def by_html(provider: str) -> AntibotResult:
+        return _create_result(True, provider, _HTML)
+
+    def by_url(provider: str) -> AntibotResult:
+        return _create_result(True, provider, _URL)
+
+    def by_status_code(provider: str) -> AntibotResult:
+        return _create_result(True, provider, _STATUS_CODE)
+
+    # Cloudflare: Check for cf-mitigated header with 'challenge' value
+    # Official docs: https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/
+    if get_header("cf-mitigated") == "challenge":
+        return by_headers("cloudflare")
+
+    # Cloudflare: cf_clearance cookie indicates Cloudflare challenge flow
+    if has_any_cookie(["cf_clearance="]):
+        return by_cookies("cloudflare")
+
+    # Vercel: Check for x-vercel-mitigated header with 'challenge' value
+    # Solver reference: https://github.com/glizzykingdreko/Vercel-Attack-Mode-Solver
+    if get_header("x-vercel-mitigated") == "challenge":
+        return by_headers("vercel")
+
+    # Akamai: Check for akamai-cache-status header starting with 'Error'
+    # Official docs: https://techdocs.akamai.com/property-mgr/docs/return-cache-status
+    akamai_cache = get_header("akamai-cache-status")
+    if akamai_cache and str(akamai_cache).startswith("Error"):
+        return by_headers("akamai")
+
+    # Akamai: Check for additional identifying headers (akamai-grn, x-akamai-session-info)
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-akamai.json
+    if has_any_header(["akamai-grn", "x-akamai-session-info"]):
+        return by_headers("akamai")
+
+    # Akamai: _abck bot manager tracking cookie
+    if has_any_cookie(["_abck="]):
+        return by_cookies("akamai")
+
+    # Akamai: Bot Manager API namespace (bmak) in html
+    if has_any_html(["bmak."]):
+        return by_html("akamai")
+
+    # DataDome: Check for x-dd-b header with values '1' (soft challenge) or '2' (hard challenge/CAPTCHA)
+    # Official docs: https://docs.datadome.co/reference/validate-request
+    if get_header("x-dd-b") in ("1", "2"):
+        return by_headers("datadome")
+
+    # DataDome: x-datadome header presence.
+    # Note: `x-datadome: protected` can appear on successful responses.
+    x_datadome = get_header("x-datadome")
+    if x_datadome and str(x_datadome).lower() != "protected":
+        return by_headers("datadome")
+
+    # DataDome: x-datadome-cid header presence
+    if has_any_header(["x-datadome-cid"]):
+        return by_headers("datadome")
+
+    # DataDome: datadome tracking cookie
+    if has_any_cookie(["datadome="]):
+        return by_cookies("datadome")
+
+    # PerimeterX: Check for X-PX-Authorization header (primary indicator)
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-perimeterx.json
+    if get_header("x-px-authorization"):
+        return by_headers("perimeterx")
+
+    # PerimeterX: Check for window._pxAppId, pxInit, or _pxAction in html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-perimeterx.json
+    if has_any_html(["window._pxAppId", "pxInit", "_pxAction"]):
+        return by_html("perimeterx")
+
+    # PerimeterX: _px3 or _pxhd cookies
+    if has_any_cookie(["_px3=", "_pxhd="]):
+        return by_cookies("perimeterx")
+
+    # Shape Security: Check for dynamic header patterns x-[8chars]-[abcdfz]
+    # These headers use 8 random characters followed by suffixes like -a, -b, -c, -d, -f, or -z
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-shapesecurity.json
+    header_names = _get_header_names(headers)
+    for name in header_names:
+        if _RE_SHAPE_HEADER.search(name):
+            return by_headers("shapesecurity")
+
+    # Shape Security: Check for 'shapesecurity' text in response html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-shapesecurity.json
+    if has_any_html(["shapesecurity"]):
+        return by_html("shapesecurity")
+
+    # Kasada: Check for x-kasada or x-kasada-challenge headers
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-kasada.json
+    if has_any_header(["x-kasada", "x-kasada-challenge"]):
+        return by_headers("kasada")
+
+    # Kasada: Check for __kasada global object or kasada.js script in html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-kasada.json
+    if has_any_html(["__kasada", "kasada.js"]):
+        return by_html("kasada")
+
+    # Imperva/Incapsula: Check for x-cdn header with 'Incapsula' value or x-iinfo header
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-incapsula.json
+    if get_header("x-cdn") == "Incapsula" or has_any_header(["x-iinfo"]):
+        return by_headers("imperva")
+
+    # Imperva/Incapsula: Check for 'incapsula' or 'imperva' text in response html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-incapsula.json
+    if has_any_html(["incapsula", "imperva"]):
+        return by_html("imperva")
+
+    # Imperva/Incapsula: incap_ses_, visid_incap_, or reese84 cookies
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-incapsula.json
+    if has_any_cookie(["incap_ses_", "visid_incap_", "reese84="]):
+        return by_cookies("imperva")
+
+    # Reblaze: rbzid or rbzsessionid cookies
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-reblaze.json
+    if has_any_cookie(["rbzid=", "rbzsessionid="]):
+        return by_cookies("reblaze")
+
+    # Reblaze: Check for 'reblaze' text in response html
+    if has_any_html(["reblaze"]):
+        return by_html("reblaze")
+
+    # Cheq: Check for CheqSdk or cheqzone.com in html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-cheq.json
+    if has_any_html(["CheqSdk", "cheqzone.com"]):
+        return by_html("cheq")
+
+    # Cheq: Check for cheqzone.com or cheq.ai in URL
+    if has_any_url([_RE_CHEQZONE, _RE_CHEQ_AI]):
+        return by_url("cheq")
+
+    # Sucuri: Check for 'sucuri' text in response html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-sucuri.json
+    if has_any_html(["sucuri"]):
+        return by_html("sucuri")
+
+    # ThreatMetrix: Check for 'ThreatMetrix' in html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-threatmetrix.json
+    if has_any_html(["ThreatMetrix"]):
+        return by_html("threatmetrix")
+
+    # ThreatMetrix: Check for fp/check.js fingerprint endpoint in URL
+    if has_any_url(["fp/check.js"]):
+        return by_url("threatmetrix")
+
+    # Meetrics: Check for 'meetrics' text in response html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-meetrics.json
+    if has_any_html(["meetrics"]):
+        return by_html("meetrics")
+
+    # Meetrics: Check for meetrics.com in URL
+    if has_any_url([_RE_MEETRICS]):
+        return by_url("meetrics")
+
+    # Ocule: Check for ocule.co.uk in html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-ocule.json
+    if has_any_html(["ocule.co.uk"]):
+        return by_html("ocule")
+
+    # Ocule: Check for ocule.co.uk in URL
+    if has_any_url([_RE_OCULE]):
+        return by_url("ocule")
+
+    # reCAPTCHA: Check for recaptcha/api, google.com/recaptcha, gstatic.com/recaptcha, or recaptcha.net in URL
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-recaptcha.json
+    if has_any_url(["recaptcha/api", "gstatic.com/recaptcha", "recaptcha.net"]) or has_any_url([_RE_GOOGLE_RECAPTCHA]):
+        return by_url("recaptcha")
+
+    # reCAPTCHA: Check for grecaptcha API usage in html (JavaScript indicator)
+    # Note: plain "grecaptcha" is too broad (e.g. ".grecaptcha-badge" CSS appears on normal YouTube pages)
+    if has_any_html([_RE_GRECAPTCHA_API, _RE_GRECAPTCHA_CALL, _RE_GRECAPTCHA_CFG]):
+        return by_html("recaptcha")
+
+    # reCAPTCHA: Check for g-recaptcha container class in html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-recaptcha.json
+    if has_any_html(["g-recaptcha"]):
+        return by_html("recaptcha")
+
+    # hCaptcha: Check for hcaptcha.com domain in URL
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-hcaptcha.json
+    if has_any_url([_RE_HCAPTCHA]):
+        return by_url("hcaptcha")
+
+    # hCaptcha: Check for hcaptcha.com API domain or h-captcha container class in html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-hcaptcha.json
+    # Note: bare 'hcaptcha' matches too broadly (could appear in articles discussing hCaptcha)
+    if has_any_html(["hcaptcha.com", "h-captcha"]):
+        return by_html("hcaptcha")
+
+    # FunCaptcha (Arkose Labs): Check for arkoselabs.com or funcaptcha in URL
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-funcaptcha.json
+    if has_any_url([_RE_ARKOSELABS]) or has_any_url(["funcaptcha"]):
+        return by_url("funcaptcha")
+
+    # FunCaptcha (Arkose Labs): Check for arkoselabs.com API domain or funcaptcha in html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-funcaptcha.json
+    # Note: bare 'arkose' matches too broadly (e.g. Facebook bundles Arkose SDK for login without blocking content)
+    if has_any_html(["arkoselabs.com", "funcaptcha"]):
+        return by_html("funcaptcha")
+
+    # GeeTest: Check for geetest.com domain in URL
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-geetest.json
+    if has_any_url([_RE_GEETEST]):
+        return by_url("geetest")
+
+    # GeeTest: Check for geetest object or text in html
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-geetest.json
+    # Note: bare 'gt.js' removed (too generic, any script named gt.js would match)
+    if has_any_html(["geetest"]):
+        return by_html("geetest")
+
+    # Cloudflare Turnstile: Check for challenges.cloudflare.com/turnstile in URL
+    if has_any_url([_RE_CF_TURNSTILE]):
+        return by_url("cloudflare-turnstile")
+
+    # Cloudflare Turnstile: Check for cf-turnstile class or turnstile API script in html
+    # Note: bare 'turnstile' matches too broadly (common English word)
+    if has_any_html(["cf-turnstile", "challenges.cloudflare.com/turnstile"]):
+        return by_html("cloudflare-turnstile")
+
+    # Friendly Captcha: Check for friendlycaptcha.com in URL
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-friendlycaptcha.json
+    if has_any_url([_RE_FRIENDLY_CAPTCHA]):
+        return by_url("friendly-captcha")
+
+    # Friendly Captcha: Check for frc-captcha container or friendlyChallenge object in html
+    if has_any_html(["frc-captcha", "friendlyChallenge"]):
+        return by_html("friendly-captcha")
+
+    # Captcha.eu: Check for captcha.eu in URL
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-captchaeu.json
+    if has_any_url([_RE_CAPTCHA_EU]):
+        return by_url("captcha-eu")
+
+    # Captcha.eu: Check for CaptchaEU or captchaeu in html
+    if has_any_html(["CaptchaEU", "captchaeu"]):
+        return by_html("captcha-eu")
+
+    # QCloud Captcha (Tencent): Check for turing.captcha.qcloud.com in URL
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-qcloud.json
+    if has_any_url([_RE_QCLOUD]):
+        return by_url("qcloud-captcha")
+
+    # QCloud Captcha: Check for TencentCaptcha or turing.captcha in html
+    if has_any_html(["TencentCaptcha", "turing.captcha"]):
+        return by_html("qcloud-captcha")
+
+    # AliExpress CAPTCHA: Check for punish?x5secdata in URL
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/captcha/detect-aliexpress.json
+    if has_any_url([_RE_ALIEXPRESS]):
+        return by_url("aliexpress-captcha")
+
+    # AliExpress CAPTCHA: Check for x5secdata in html
+    if has_any_html(["x5secdata"]):
+        return by_html("aliexpress-captcha")
+
+    # Reddit: blocked requests are served as HTML challenge pages.
+    if _get_domain(url) == "reddit.com":
+        if status_code == 403:
+            return by_status_code("reddit")
+        if has_any_html([_RE_REDDIT_BLOCKED]):
+            return by_html("reddit")
+
+    # LinkedIn: status 999 is LinkedIn's dedicated bot-detection response
+    if _get_domain(url) == "linkedin.com" and status_code == 999:
+        return by_status_code("linkedin")
+
+    # Instagram: login page redirect indicates bot detection
+    if _get_domain(url) == "instagram.com" and has_any_html([_RE_INSTAGRAM_LOGIN]):
+        return by_html("instagram")
+
+    # YouTube: empty title pattern indicates a degraded response requiring BotGuard JS attestation
+    # Normal pages have `<title>Video Title - YouTube</title>`, bots get `<title> - YouTube</title>`
+    if has_any_html([_RE_YOUTUBE_EMPTY]):
+        return by_html("youtube")
+
+    # Anubis (Techaro BotStopper): challenge pages always contain the JSON script block
+    # `<script id="anubis_challenge" type="application/json">` (hardcoded in web/index.templ)
+    # and asset/API URLs under the Go constant `StaticPath = "/.within.website/x/cmd/anubis/"`.
+    # Source: https://github.com/TecharoHQ/anubis
+    if has_any_html([_RE_ANUBIS_SCRIPT, "/.within.website/x/cmd/anubis/"]):
+        return by_html("anubis")
+
+    # AWS WAF: Check for x-amzn-waf-action or x-amzn-requestid headers
+    # Reference: https://github.com/scrapfly/Antibot-Detector/blob/main/detectors/antibot/detect-aws-waf.json
+    if has_any_header(["x-amzn-waf-action", "x-amzn-requestid"]):
+        return by_headers("aws-waf")
+
+    # AWS WAF: Check for aws-waf or awswaf text in html
+    if has_any_html(["aws-waf", "awswaf"]):
+        return by_html("aws-waf")
+
+    # AWS WAF: aws-waf-token cookie
+    if has_any_cookie(["aws-waf-token="]):
+        return by_cookies("aws-waf")
+
+    return _create_result(False, None, None)
+
+
+def _create_result(detected: bool, provider: str | None, detection: str | None) -> AntibotResult:
+    """Create and log an antibot detection result."""
+    logger.debug("detected=%s provider=%s detection=%s", detected, provider, detection)
+    return AntibotResult(detected=detected, provider=provider, detection=detection)
+
+
+def is_antibot(
+    *,
+    headers: Mapping[str, str | list[str] | None] | None = None,
+    html: str | None = None,
+    body: str | None = None,
+    url: str | None = None,
+    status_code: int | None = None,
+    status: int | None = None,
+) -> AntibotResult:
+    """Detect antibot protection from response data.
+
+    Args:
+        headers: Response headers as a dict-like mapping.
+        html: Response HTML body.
+        body: Alias for html.
+        url: The request URL.
+        status_code: HTTP status code.
+        status: Alias for status_code.
+
+    Returns:
+        AntibotResult with detected, provider, and detection fields.
+    """
+    return _detect(
+        headers=headers or {},
+        html=html or body or "",
+        url=url or "",
+        status_code=status_code if status_code is not None else status,
+    )
+
+
+__all__ = ["is_antibot", "create_test_pattern", "create_has_cookie", "AntibotResult"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,63 @@
+"""Shared test utilities for is_antibot tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+PROVIDERS_PATH = Path(__file__).resolve().parent.parent / "providers"
+
+
+def _headers_from_har(response: dict) -> dict[str, str | list[str]]:
+    """Convert HAR header format [{name, value}, ...] to a dict.
+
+    Duplicate header names are collected into a list.
+    """
+    result: dict[str, str | list[str]] = {}
+    for header in response["headers"]:
+        name = header["name"]
+        value = header["value"]
+        existing = result.get(name)
+        if existing is not None:
+            if isinstance(existing, list):
+                existing.append(value)
+            else:
+                result[name] = [existing, value]
+        else:
+            result[name] = value
+    return result
+
+
+def load_fixture(filepath: str | Path) -> dict:
+    """Load a HAR fixture and return a dict suitable for is_antibot()."""
+    raw = Path(filepath).read_text(encoding="utf-8")
+    data = json.loads(raw)
+    response = data["log"]["entries"][0]["response"]
+    request = data["log"]["entries"][0].get("request", {})
+    return {
+        "headers": _headers_from_har(response),
+        "status_code": response["status"],
+        "html": (response.get("content") or {}).get("text", ""),
+        "url": request.get("url", ""),
+    }
+
+
+def _discover_provider_fixtures() -> dict[str, list[dict[str, str]]]:
+    """Scan the providers/ directory for failed.json and success.json fixtures."""
+    fixtures: dict[str, list[dict[str, str]]] = {"failed": [], "success": []}
+    if not PROVIDERS_PATH.is_dir():
+        return fixtures
+    for child in sorted(PROVIDERS_PATH.iterdir()):
+        if not child.is_dir():
+            continue
+        name = child.name
+        failed = child / "failed.json"
+        success = child / "success.json"
+        if failed.exists():
+            fixtures["failed"].append({"name": name, "path": str(failed)})
+        if success.exists():
+            fixtures["success"].append({"name": name, "path": str(success)})
+    return fixtures
+
+
+PROVIDER_FIXTURES = _discover_provider_fixtures()

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,0 +1,57 @@
+"""Cookie parsing tests — port of test/set-cookie.js."""
+
+from __future__ import annotations
+
+from is_antibot import create_has_cookie
+
+
+def test_array_got_style():
+    has_cookie = create_has_cookie({"set-cookie": ["foo=bar", "trkCode=bf; Max-Age=5"]})
+    assert has_cookie("trkCode=bf") is True
+    assert has_cookie("foo=bar") is True
+    assert has_cookie("missing=value") is False
+
+
+def test_comma_joined_string_fetch_style():
+    has_cookie = create_has_cookie({"set-cookie": "foo=bar; Max-Age=5, trkCode=bf; Max-Age=5"})
+    assert has_cookie("trkCode=bf") is True
+    assert has_cookie("foo=bar") is True
+    assert has_cookie("missing=value") is False
+
+
+def test_single_string():
+    has_cookie = create_has_cookie({"set-cookie": "trkCode=bf; Max-Age=5"})
+    assert has_cookie("trkCode=bf") is True
+    assert has_cookie("missing=value") is False
+
+
+def test_fetch_headers_object():
+    """Test with a dict that has a get method (simulating Fetch Headers)."""
+    has_cookie = create_has_cookie({"set-cookie": "foo=bar, trkCode=bf; Max-Age=5"})
+    assert has_cookie("trkCode=bf") is True
+    assert has_cookie("missing=value") is False
+
+
+def test_comma_in_expires_no_false_split():
+    has_cookie = create_has_cookie({"set-cookie": "trkCode=bf; expires=Thu, 26-Mar-26 09:08:53 GMT; path=/"})
+    assert has_cookie("trkCode=bf") is True
+
+
+def test_no_set_cookie_header():
+    has_cookie = create_has_cookie({})
+    assert has_cookie("trkCode=bf") is False
+
+
+def test_undefined_set_cookie():
+    has_cookie = create_has_cookie({"set-cookie": None})
+    assert has_cookie("trkCode=bf") is False
+
+
+def test_empty_string():
+    has_cookie = create_has_cookie({"set-cookie": ""})
+    assert has_cookie("trkCode=bf") is False
+
+
+def test_empty_array():
+    has_cookie = create_has_cookie({"set-cookie": []})
+    assert has_cookie("trkCode=bf") is False

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,0 +1,752 @@
+"""Provider detection tests — port of test/index.js."""
+
+from __future__ import annotations
+
+from is_antibot import create_test_pattern, is_antibot
+
+
+def test_cloudflare_cf_mitigated_header():
+    headers = {"cf-mitigated": "challenge"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "cloudflare"
+    assert result.detection == "headers"
+
+
+def test_cloudflare_cf_clearance_set_cookie():
+    headers = {"set-cookie": "cf_clearance=abc123; path=/"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "cloudflare"
+    assert result.detection == "cookies"
+
+
+def test_vercel():
+    headers = {"x-vercel-mitigated": "challenge"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "vercel"
+
+
+def test_akamai_cache_status_error():
+    headers = {"akamai-cache-status": "Error from child"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "akamai"
+
+
+def test_akamai_grn_header():
+    headers = {"akamai-grn": "test123"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "akamai"
+
+
+def test_akamai_abck_set_cookie():
+    headers = {"set-cookie": "_abck=abc123~0~; path=/"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "akamai"
+
+
+def test_akamai_bmak_in_html():
+    html = '<script>bmak.sensor_data = "test";</script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "akamai"
+
+
+def test_akamai_no_antibot():
+    headers = {"akamai-cache-status": "HIT"}
+    result = is_antibot(headers=headers)
+    assert result.detected is False
+    assert result.provider is None
+    assert result.detection is None
+
+
+def test_datadome_x_dd_b_header():
+    for value in ("1", "2"):
+        headers = {"x-dd-b": value}
+        result = is_antibot(headers=headers)
+        assert result.detected is True, f"should detect datadome for x-dd-b={value}"
+        assert result.provider == "datadome"
+
+
+def test_datadome_x_datadome_header():
+    headers = {"x-datadome": "test"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "datadome"
+
+
+def test_datadome_x_datadome_protected_is_not_enough():
+    headers = {"x-datadome": "protected"}
+    result = is_antibot(headers=headers)
+    assert result.detected is False
+    assert result.provider is None
+
+
+def test_datadome_x_datadome_cid_header():
+    headers = {"x-datadome-cid": "abc123"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "datadome"
+
+
+def test_datadome_set_cookie():
+    headers = {"set-cookie": "datadome=abc123; path=/"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "datadome"
+
+
+def test_perimeterx_header():
+    headers = {"x-px-authorization": "test"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "perimeterx"
+
+
+def test_perimeterx_html_window_pxappid():
+    html = '<script>window._pxAppId = "PX123";</script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "perimeterx"
+
+
+def test_perimeterx_html_pxinit():
+    html = "<script>pxInit();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "perimeterx"
+
+
+def test_perimeterx_html_pxaction():
+    html = '<script>var _pxAction = "c";</script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "perimeterx"
+
+
+def test_perimeterx_px3_set_cookie():
+    headers = {"set-cookie": "_px3=abc123; path=/"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "perimeterx"
+
+
+def test_perimeterx_pxhd_set_cookie():
+    headers = {"set-cookie": "_pxhd=abc123; path=/"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "perimeterx"
+
+
+def test_shapesecurity_header():
+    headers = {"x-abc12345-a": "test"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "shapesecurity"
+
+
+def test_shapesecurity_html():
+    html = "<script>shapesecurity.init();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "shapesecurity"
+
+
+def test_kasada_header():
+    headers = {"x-kasada": "test"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "kasada"
+
+
+def test_kasada_html():
+    html = "<script>__kasada.init();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "kasada"
+
+
+def test_imperva_header():
+    headers = {"x-cdn": "Incapsula"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "imperva"
+
+
+def test_imperva_html_with_incapsula():
+    html = "<script>incapsula.init();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "imperva"
+
+
+def test_imperva_html_with_imperva():
+    html = "<script>imperva.protect();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "imperva"
+
+
+def test_imperva_incap_ses_set_cookie():
+    headers = {"set-cookie": "incap_ses_123=abc; path=/"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "imperva"
+
+
+def test_imperva_visid_incap_set_cookie():
+    headers = {"set-cookie": "visid_incap_456=xyz; path=/"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "imperva"
+
+
+def test_imperva_reese84_set_cookie():
+    headers = {"set-cookie": "reese84=abc123; path=/"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "imperva"
+
+
+def test_reblaze_rbzid_set_cookie():
+    headers = {"set-cookie": "rbzid=abc123; path=/"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "reblaze"
+
+
+def test_reblaze_rbzsessionid_set_cookie():
+    headers = {"set-cookie": "rbzsessionid=xyz; path=/"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "reblaze"
+
+
+def test_reblaze_html():
+    html = "<p>Protected by Reblaze</p>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "reblaze"
+    assert result.detection == "html"
+
+
+def test_cheq_html_cheqsdk():
+    html = "<script>CheqSdk.init();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "cheq"
+
+
+def test_cheq_html_cheqzone_com():
+    html = '<script src="https://ob.cheqzone.com/script.js"></script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "cheq"
+
+
+def test_cheq_url_cheqzone_com():
+    url = "https://ob.cheqzone.com/script.js"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "cheq"
+    assert result.detection == "url"
+
+
+def test_cheq_url_cheq_ai():
+    url = "https://cheq.ai/api/verify"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "cheq"
+
+
+def test_sucuri_html():
+    html = "<p>Sucuri Website Firewall - Access Denied</p>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "sucuri"
+
+
+def test_threatmetrix_html():
+    html = "<script>ThreatMetrix.init();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "threatmetrix"
+
+
+def test_threatmetrix_url_fp_check_js():
+    url = "https://example.com/fp/check.js?org_id=abc"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "threatmetrix"
+
+
+def test_meetrics_html():
+    html = "<script>meetricsGlobal.init();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "meetrics"
+
+
+def test_meetrics_url():
+    url = "https://s418.mxcdn.net/bb-mx/serve/meetrics.com/script"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "meetrics"
+
+
+def test_ocule_html():
+    html = '<script src="https://proxy.ocule.co.uk/script.js"></script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "ocule"
+
+
+def test_ocule_url():
+    url = "https://proxy.ocule.co.uk/script.js"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "ocule"
+
+
+def test_recaptcha_url_with_recaptcha_api():
+    url = "https://www.google.com/recaptcha/api.js"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "recaptcha"
+
+
+def test_recaptcha_url_with_google_com_recaptcha():
+    url = "https://google.com/recaptcha/enterprise.js"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "recaptcha"
+
+
+def test_recaptcha_url_with_gstatic_com_recaptcha():
+    url = "https://www.gstatic.com/recaptcha/releases/abc/recaptcha.js"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "recaptcha"
+
+
+def test_recaptcha_url_with_recaptcha_net():
+    url = "https://recaptcha.net/recaptcha/api.js"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "recaptcha"
+
+
+def test_recaptcha_html_grecaptcha():
+    html = "<script>grecaptcha.execute();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "recaptcha"
+
+
+def test_recaptcha_no_false_positive_for_grecaptcha_badge_css():
+    html = '<style>.grecaptcha-badge{visibility:hidden}</style><title>My Video - YouTube</title>'
+    result = is_antibot(html=html)
+    assert result.detected is False
+    assert result.provider is None
+
+
+def test_recaptcha_html_g_recaptcha():
+    html = '<div class="g-recaptcha" data-sitekey="test"></div>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "recaptcha"
+
+
+def test_hcaptcha_url():
+    url = "https://hcaptcha.com/captcha/v1"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "hcaptcha"
+
+
+def test_hcaptcha_html_hcaptcha_com():
+    html = '<script src="https://hcaptcha.com/1/api.js"></script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "hcaptcha"
+
+
+def test_hcaptcha_no_false_positive_for_bare_hcaptcha_mention():
+    html = "<p>We use hcaptcha for bot protection.</p>"
+    result = is_antibot(html=html)
+    assert result.detected is False
+
+
+def test_hcaptcha_html_h_captcha():
+    html = '<div class="h-captcha"></div>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "hcaptcha"
+
+
+def test_funcaptcha_url_with_arkoselabs():
+    url = "https://client-api.arkoselabs.com/fc/gc/"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "funcaptcha"
+
+
+def test_funcaptcha_url_with_funcaptcha():
+    url = "https://api.funcaptcha.com/fc/gt2/public_key/test"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "funcaptcha"
+
+
+def test_funcaptcha_html_with_funcaptcha():
+    html = "<script>funcaptcha.init();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "funcaptcha"
+
+
+def test_funcaptcha_html_with_arkoselabs_com():
+    html = '<script src="https://client-api.arkoselabs.com/fc/assets/loader.js"></script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "funcaptcha"
+
+
+def test_funcaptcha_no_false_positive_for_bare_arkose_mention():
+    html = '<script>window.__arkose_config = {};</script><meta property="og:title" content="Real content">'
+    result = is_antibot(html=html)
+    assert result.detected is False
+
+
+def test_geetest_url():
+    url = "https://api.geetest.com/ajax.php"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "geetest"
+
+
+def test_geetest_html():
+    html = "<script>geetest.init();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "geetest"
+
+
+def test_geetest_no_false_positive_for_generic_gt_js():
+    html = '<script src="/static/gt.js"></script>'
+    result = is_antibot(html=html)
+    assert result.detected is False
+
+
+def test_cloudflare_turnstile_url():
+    url = "https://challenges.cloudflare.com/turnstile/v0/api.js"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "cloudflare-turnstile"
+
+
+def test_cloudflare_turnstile_html_cf_turnstile():
+    html = '<div class="cf-turnstile"></div>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "cloudflare-turnstile"
+
+
+def test_cloudflare_turnstile_html_turnstile_api():
+    html = '<script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "cloudflare-turnstile"
+
+
+def test_cloudflare_turnstile_no_false_positive_for_bare_turnstile_word():
+    html = "<p>The subway turnstile was broken.</p>"
+    result = is_antibot(html=html)
+    assert result.detected is False
+
+
+def test_friendly_captcha_url():
+    url = "https://cdn.friendlycaptcha.com/modules/v2/widget.js"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "friendly-captcha"
+
+
+def test_friendly_captcha_html_frc_captcha():
+    html = '<div class="frc-captcha" data-sitekey="test"></div>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "friendly-captcha"
+
+
+def test_friendly_captcha_html_friendlychallenge():
+    html = "<script>friendlyChallenge.render();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "friendly-captcha"
+
+
+def test_captcha_eu_url():
+    url = "https://www.captcha.eu/widget/api.js"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "captcha-eu"
+
+
+def test_captcha_eu_html_captchaeu():
+    html = "<script>CaptchaEU.render();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "captcha-eu"
+
+
+def test_captcha_eu_html_captchaeu_widget():
+    html = '<div class="captchaeu-widget"></div>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "captcha-eu"
+
+
+def test_qcloud_captcha_url():
+    url = "https://turing.captcha.qcloud.com/tdc.js"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "qcloud-captcha"
+
+
+def test_qcloud_captcha_html_tencentcaptcha():
+    html = '<script>new TencentCaptcha("appid");</script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "qcloud-captcha"
+
+
+def test_qcloud_captcha_html_turing_captcha():
+    html = '<script src="//turing.captcha.gtimg.com/tdc.js"></script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "qcloud-captcha"
+
+
+def test_aliexpress_captcha_url():
+    url = "https://www.aliexpress.com/punish?x5secdata=abc123"
+    result = is_antibot(url=url)
+    assert result.detected is True
+    assert result.provider == "aliexpress-captcha"
+
+
+def test_aliexpress_captcha_html():
+    html = '<script>var x5secdata = "abc123";</script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "aliexpress-captcha"
+
+
+def test_reddit_blocked_html():
+    html = "<div>blocked by network security.</div>"
+    url = "https://www.reddit.com/r/lotus/comments/1pzbv0z/my_lotus_elise_72d_with_17_rays_volk_gtp/"
+    result = is_antibot(html=html, url=url)
+    assert result.detected is True
+    assert result.provider == "reddit"
+    assert result.detection == "html"
+
+
+def test_reddit_blocked_html_on_non_reddit_url_should_not_match():
+    html = "<div>blocked by network security.</div>"
+    url = "https://example.com/some/path"
+    result = is_antibot(html=html, url=url)
+    assert result.detected is False
+    assert result.provider is None
+
+
+def test_reddit_blocked_by_status_code():
+    headers = {
+        "content-type": "text/html",
+        "server": "snooserv",
+        "cache-control": "private, no-store",
+    }
+    url = "https://www.reddit.com/r/digitalnomad/comments/1riz2r5/i_love_mexico_city_but_i_feel_so_unhealthy_here/"
+    result = is_antibot(headers=headers, url=url, status_code=403)
+    assert result.detected is True
+    assert result.provider == "reddit"
+    assert result.detection == "status_code"
+
+
+def test_reddit_allowed_endpoint():
+    headers = {
+        "content-type": "application/json; charset=UTF-8",
+        "server": "snooserv",
+    }
+    url = "https://www.reddit.com/r/lotus/comments/1pzbv0z/my_lotus_elise_72d_with_17_rays_volk_gtp/"
+    result = is_antibot(headers=headers, url=url)
+    assert result.detected is False
+    assert result.provider is None
+
+
+def test_linkedin_status_999():
+    result = is_antibot(status_code=999, url="https://www.linkedin.com/in/wesbos")
+    assert result.detected is True
+    assert result.provider == "linkedin"
+    assert result.detection == "status_code"
+
+
+def test_linkedin_status_999_ignored_for_non_linkedin_url():
+    result = is_antibot(status_code=999, url="https://example.com")
+    assert result.detected is False
+    assert result.provider is None
+
+
+def test_linkedin_no_antibot_without_status_999():
+    headers = {
+        "x-li-fabric": "prod-lor1",
+        "set-cookie": "other=value; Max-Age=5",
+    }
+    result = is_antibot(headers=headers, status_code=200)
+    assert result.detected is False
+    assert result.provider is None
+
+
+def test_instagram_login_page_redirect():
+    html = "<!DOCTYPE html><html lang=\"en\"><head><title>Login \u2022 Instagram</title></head><body></body></html>"
+    result = is_antibot(html=html, url="https://www.instagram.com/kikobeats/")
+    assert result.detected is True
+    assert result.provider == "instagram"
+    assert result.detection == "html"
+
+
+def test_youtube_empty_title_in_html():
+    html = (
+        "<!DOCTYPE html><html><head><title> - YouTube</title></head>"
+        '<body><ytd-app disable-upgrade="true"></ytd-app></body></html>'
+    )
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "youtube"
+
+
+def test_youtube_no_antibot_with_normal_title():
+    html = "<!DOCTYPE html><html><head><title>My Video - YouTube</title></head><body></body></html>"
+    result = is_antibot(html=html)
+    assert result.detected is False
+    assert result.provider is None
+
+
+def test_anubis_html_anubis_challenge_script_tag():
+    html = '<script id="anubis_challenge" type="application/json">{"rules":{"algorithm":"metarefresh"}}</script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "anubis"
+    assert result.detection == "html"
+
+
+def test_anubis_html_static_path():
+    html = '<img src="https://example.com/.within.website/x/cmd/anubis/static/img/pensive.webp">'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "anubis"
+    assert result.detection == "html"
+
+
+def test_anubis_no_false_positive_for_anubis_challenge_in_plain_text():
+    html = "<p>The template uses anubis_challenge as a key</p>"
+    result = is_antibot(html=html, headers={})
+    assert result.detected is False
+
+
+def test_anubis_no_false_positive_for_anubis_challenge_as_non_script_element():
+    html = '<div id="anubis_challenge">some content</div>'
+    result = is_antibot(html=html, headers={})
+    assert result.detected is False
+
+
+def test_anubis_no_false_positive_for_within_website_in_html_text():
+    html = "<p>Read more at within.website blog</p>"
+    result = is_antibot(html=html, headers={})
+    assert result.detected is False
+
+
+def test_aws_waf_header():
+    headers = {"x-amzn-waf-action": "CHALLENGE"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "aws-waf"
+
+
+def test_aws_waf_html_aws_waf():
+    html = "<script>aws-waf.init();</script>"
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "aws-waf"
+
+
+def test_aws_waf_html_awswaf():
+    html = '<script src="/awswaf/challenge.js"></script>'
+    result = is_antibot(html=html)
+    assert result.detected is True
+    assert result.provider == "aws-waf"
+
+
+def test_aws_waf_token_set_cookie():
+    headers = {"set-cookie": "aws-waf-token=abc123; path=/"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "aws-waf"
+
+
+def test_create_test_pattern_with_invalid_regex_catches_error():
+    has = create_test_pattern("test")
+    assert has("[invalid(regex") is False
+
+
+def test_test_pattern_with_invalid_regex():
+    result = is_antibot(url="test", html="test")
+    # Should not throw and should return no detection
+    assert result.detected is False
+    assert result.provider is None
+
+
+def test_general_no_antibot():
+    result = is_antibot(headers={})
+    assert result.detected is False
+    assert result.provider is None
+
+
+def test_no_headers_provided():
+    result = is_antibot()
+    assert result.detected is False
+    assert result.provider is None
+
+
+def test_support_dict_headers():
+    """Test with plain dict headers (Python equivalent of Headers object)."""
+    headers = {"cf-mitigated": "challenge"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "cloudflare"
+
+
+def test_support_response_headers_only():
+    """Test with dict headers simulating a Response object."""
+    headers = {"cf-mitigated": "challenge"}
+    result = is_antibot(headers=headers)
+    assert result.detected is True
+    assert result.provider == "cloudflare"
+
+
+def test_support_fetch_response_with_text():
+    """Test with headers dict and html body (Python equivalent of Fetch Response)."""
+    headers = {"x-dd-b": "2"}
+    html = "<script>grecaptcha.execute();</script>"
+    result = is_antibot(headers=headers, html=html)
+    assert result.detected is True
+    assert result.provider == "datadome"
+
+
+def test_fallback_body_string_to_html():
+    result = is_antibot(body="<script>grecaptcha.execute();</script>")
+    assert result.detected is True
+    assert result.provider == "recaptcha"

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,32 @@
+"""HAR fixture tests — port of test/providers.js."""
+
+from __future__ import annotations
+
+import pytest
+from conftest import PROVIDER_FIXTURES, load_fixture
+
+from is_antibot import is_antibot
+
+
+@pytest.mark.parametrize(
+    "name,fixture_path",
+    [(f["name"], f["path"]) for f in PROVIDER_FIXTURES["failed"]],
+    ids=[f["name"] for f in PROVIDER_FIXTURES["failed"]],
+)
+def test_fixture_detected(name: str, fixture_path: str):
+    fixture = load_fixture(fixture_path)
+    result = is_antibot(**fixture)
+    assert result.detected is True, f"Failed {name}"
+    assert result.provider, f"Failed {name}"
+
+
+@pytest.mark.parametrize(
+    "name,fixture_path",
+    [(f["name"], f["path"]) for f in PROVIDER_FIXTURES["success"]],
+    ids=[f["name"] for f in PROVIDER_FIXTURES["success"]],
+)
+def test_fixture_not_detected(name: str, fixture_path: str):
+    fixture = load_fixture(fixture_path)
+    result = is_antibot(**fixture)
+    assert result.detected is False, f"Failed {name}"
+    assert result.provider is None, f"Failed {name}"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,404 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/33/e8c48488c29a73fd089f9d71f9653c1be7478f2ad6b5bc870db11a55d23d/coverage-7.13.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0723d2c96324561b9aa76fb982406e11d93cdb388a7a7da2b16e04719cf7ca5", size = 219255, upload-time = "2026-03-17T10:29:51.081Z" },
+    { url = "https://files.pythonhosted.org/packages/da/bd/b0ebe9f677d7f4b74a3e115eec7ddd4bcf892074963a00d91e8b164a6386/coverage-7.13.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52f444e86475992506b32d4e5ca55c24fc88d73bcbda0e9745095b28ef4dc0cf", size = 219772, upload-time = "2026-03-17T10:29:52.867Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cc/5cb9502f4e01972f54eedd48218bb203fe81e294be606a2bc93970208013/coverage-7.13.5-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:704de6328e3d612a8f6c07000a878ff38181ec3263d5a11da1db294fa6a9bdf8", size = 246532, upload-time = "2026-03-17T10:29:54.688Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d8/3217636d86c7e7b12e126e4f30ef1581047da73140614523af7495ed5f2d/coverage-7.13.5-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a1a6d79a14e1ec1832cabc833898636ad5f3754a678ef8bb4908515208bf84f4", size = 248333, upload-time = "2026-03-17T10:29:56.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/30/2002ac6729ba2d4357438e2ed3c447ad8562866c8c63fc16f6dfc33afe56/coverage-7.13.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79060214983769c7ba3f0cee10b54c97609dca4d478fa1aa32b914480fd5738d", size = 250211, upload-time = "2026-03-17T10:29:57.938Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/85/552496626d6b9359eb0e2f86f920037c9cbfba09b24d914c6e1528155f7d/coverage-7.13.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:356e76b46783a98c2a2fe81ec79df4883a1e62895ea952968fb253c114e7f930", size = 252125, upload-time = "2026-03-17T10:29:59.388Z" },
+    { url = "https://files.pythonhosted.org/packages/44/21/40256eabdcbccdb6acf6b381b3016a154399a75fe39d406f790ae84d1f3c/coverage-7.13.5-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0cef0cdec915d11254a7f549c1170afecce708d30610c6abdded1f74e581666d", size = 247219, upload-time = "2026-03-17T10:30:01.199Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/96e2a6c3f21a0ea77d7830b254a1542d0328acc8d7bdf6a284ba7e529f77/coverage-7.13.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dc022073d063b25a402454e5712ef9e007113e3a676b96c5f29b2bda29352f40", size = 248248, upload-time = "2026-03-17T10:30:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ba/8477f549e554827da390ec659f3c38e4b6d95470f4daafc2d8ff94eaa9c2/coverage-7.13.5-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9b74db26dfea4f4e50d48a4602207cd1e78be33182bc9cbf22da94f332f99878", size = 246254, upload-time = "2026-03-17T10:30:04.832Z" },
+    { url = "https://files.pythonhosted.org/packages/55/59/bc22aef0e6aa179d5b1b001e8b3654785e9adf27ef24c93dc4228ebd5d68/coverage-7.13.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad146744ca4fd09b50c482650e3c1b1f4dfa1d4792e0a04a369c7f23336f0400", size = 250067, upload-time = "2026-03-17T10:30:06.535Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1b/c6a023a160806a5137dca53468fd97530d6acad24a22003b1578a9c2e429/coverage-7.13.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:c555b48be1853fe3997c11c4bd521cdd9a9612352de01fa4508f16ec341e6fe0", size = 246521, upload-time = "2026-03-17T10:30:08.486Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3f/3532c85a55aa2f899fa17c186f831cfa1aa434d88ff792a709636f64130e/coverage-7.13.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7034b5c56a58ae5e85f23949d52c14aca2cfc6848a31764995b7de88f13a1ea0", size = 247126, upload-time = "2026-03-17T10:30:09.966Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2e/b9d56af4a24ef45dfbcda88e06870cb7d57b2b0bfa3a888d79b4c8debd76/coverage-7.13.5-cp310-cp310-win32.whl", hash = "sha256:eb7fdf1ef130660e7415e0253a01a7d5a88c9c4d158bcf75cbbd922fd65a5b58", size = 221860, upload-time = "2026-03-17T10:30:11.393Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cc/d938417e7a4d7f0433ad4edee8bb2acdc60dc7ac5af19e2a07a048ecbee3/coverage-7.13.5-cp310-cp310-win_amd64.whl", hash = "sha256:3e1bb5f6c78feeb1be3475789b14a0f0a5b47d505bfc7267126ccbd50289999e", size = 222788, upload-time = "2026-03-17T10:30:12.886Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/37/d24c8f8220ff07b839b2c043ea4903a33b0f455abe673ae3c03bbdb7f212/coverage-7.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:66a80c616f80181f4d643b0f9e709d97bcea413ecd9631e1dedc7401c8e6695d", size = 219381, upload-time = "2026-03-17T10:30:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8b/cd129b0ca4afe886a6ce9d183c44d8301acbd4ef248622e7c49a23145605/coverage-7.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:145ede53ccbafb297c1c9287f788d1bc3efd6c900da23bf6931b09eafc931587", size = 219880, upload-time = "2026-03-17T10:30:16.231Z" },
+    { url = "https://files.pythonhosted.org/packages/55/2f/e0e5b237bffdb5d6c530ce87cc1d413a5b7d7dfd60fb067ad6d254c35c76/coverage-7.13.5-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0672854dc733c342fa3e957e0605256d2bf5934feeac328da9e0b5449634a642", size = 250303, upload-time = "2026-03-17T10:30:17.748Z" },
+    { url = "https://files.pythonhosted.org/packages/92/be/b1afb692be85b947f3401375851484496134c5554e67e822c35f28bf2fbc/coverage-7.13.5-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ec10e2a42b41c923c2209b846126c6582db5e43a33157e9870ba9fb70dc7854b", size = 252218, upload-time = "2026-03-17T10:30:19.804Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/2f47bb6fa1b8d1e3e5d0c4be8ccb4313c63d742476a619418f85740d597b/coverage-7.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be3d4bbad9d4b037791794ddeedd7d64a56f5933a2c1373e18e9e568b9141686", size = 254326, upload-time = "2026-03-17T10:30:21.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d0/79db81da58965bd29dabc8f4ad2a2af70611a57cba9d1ec006f072f30a54/coverage-7.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d2afbc5cc54d286bfb54541aa50b64cdb07a718227168c87b9e2fb8f25e1743", size = 256267, upload-time = "2026-03-17T10:30:23.094Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/32/d0d7cc8168f91ddab44c0ce4806b969df5f5fdfdbb568eaca2dbc2a04936/coverage-7.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3ad050321264c49c2fa67bb599100456fc51d004b82534f379d16445da40fb75", size = 250430, upload-time = "2026-03-17T10:30:25.311Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/06/a055311d891ddbe231cd69fdd20ea4be6e3603ffebddf8704b8ca8e10a3c/coverage-7.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7300c8a6d13335b29bb76d7651c66af6bd8658517c43499f110ddc6717bfc209", size = 252017, upload-time = "2026-03-17T10:30:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f6/d0fd2d21e29a657b5f77a2fe7082e1568158340dceb941954f776dce1b7b/coverage-7.13.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:eb07647a5738b89baab047f14edd18ded523de60f3b30e75c2acc826f79c839a", size = 250080, upload-time = "2026-03-17T10:30:29.481Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ab/0d7fb2efc2e9a5eb7ddcc6e722f834a69b454b7e6e5888c3a8567ecffb31/coverage-7.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9adb6688e3b53adffefd4a52d72cbd8b02602bfb8f74dcd862337182fd4d1a4e", size = 253843, upload-time = "2026-03-17T10:30:31.301Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/6f/7467b917bbf5408610178f62a49c0ed4377bb16c1657f689cc61470da8ce/coverage-7.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7c8d4bc913dd70b93488d6c496c77f3aff5ea99a07e36a18f865bca55adef8bd", size = 249802, upload-time = "2026-03-17T10:30:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2c/1172fb689df92135f5bfbbd69fc83017a76d24ea2e2f3a1154007e2fb9f8/coverage-7.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0e3c426ffc4cd952f54ee9ffbdd10345709ecc78a3ecfd796a57236bfad0b9b8", size = 250707, upload-time = "2026-03-17T10:30:35.2Z" },
+    { url = "https://files.pythonhosted.org/packages/67/21/9ac389377380a07884e3b48ba7a620fcd9dbfaf1d40565facdc6b36ec9ef/coverage-7.13.5-cp311-cp311-win32.whl", hash = "sha256:259b69bb83ad9894c4b25be2528139eecba9a82646ebdda2d9db1ba28424a6bf", size = 221880, upload-time = "2026-03-17T10:30:36.775Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7f/4cd8a92531253f9d7c1bbecd9fa1b472907fb54446ca768c59b531248dc5/coverage-7.13.5-cp311-cp311-win_amd64.whl", hash = "sha256:258354455f4e86e3e9d0d17571d522e13b4e1e19bf0f8596bcf9476d61e7d8a9", size = 222816, upload-time = "2026-03-17T10:30:38.891Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a6/1d3f6155fb0010ca68eba7fe48ca6c9da7385058b77a95848710ecf189b1/coverage-7.13.5-cp311-cp311-win_arm64.whl", hash = "sha256:bff95879c33ec8da99fc9b6fe345ddb5be6414b41d6d1ad1c8f188d26f36e028", size = 221483, upload-time = "2026-03-17T10:30:40.463Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "is-antibot"
+version = "1.7.1"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+lint = [
+    { name = "ruff" },
+]
+test = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+lint = [{ name = "ruff" }]
+test = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
+    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
+    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
+    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
+    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
+    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
## Summary
- Port the full `is-antibot` JS library to Python with zero runtime dependencies, using `dataclass` result types, pre-compiled regex patterns, and a keyword-only public API
- Port all 119 tests (detection, cookie parsing, HAR fixtures) to pytest with full parity against the JS test suite
- Configure `pyproject.toml` with hatchling build, ruff linting, and pytest; add PEP 561 `py.typed` marker

## Test plan
- [x] `uv sync && uv run pytest -v` -- all 119 tests pass
- [x] `uv run ruff check src/ tests/` -- zero lint errors
- [ ] Verify `uv build` produces a valid wheel
- [ ] Spot-check detection parity on a few real-world HAR fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)