### PR TITLE
chore: emit a dispatch event under new version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           version: latest
       - name: Install
-        run: pnpm install --ignore-scripts
+        run: pnpm install --dangerously-allow-all-builds
       - name: Test
         run: pnpm test
       - name: Report
@@ -59,6 +59,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -66,4 +67,39 @@ jobs:
           git config --global user.email ${{ secrets.GIT_EMAIL }}
           git config --global user.name ${{ secrets.GIT_USERNAME }}
           git pull origin master
+          VERSION_BEFORE=$(node -p "require('./package.json').version")
           pnpm run release
+          VERSION_AFTER=$(node -p "require('./package.json').version")
+          if [ "$VERSION_BEFORE" != "$VERSION_AFTER" ]; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "version=v${VERSION_AFTER}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Dispatch release event
+        if: steps.release.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          REPOS=(
+            "musantro/is-antibot"
+          )
+          VERSION="${{ steps.release.outputs.version }}"
+          PAYLOAD=$(jq -n \
+            --arg repo "${{ github.repository }}" \
+            --arg version "$VERSION" \
+            --arg sha "${{ github.sha }}" \
+            '{
+              "event_type": "is-antibot-release-published",
+              "client_payload": {
+                "sourceRepository": $repo,
+                "version": $version,
+                "tagName": $version,
+                "sha": $sha,
+                "url": "https://github.com/\($repo)/releases/tag/\($version)",
+                "providersUrl": "https://raw.githubusercontent.com/\($repo)/\($version)/src/providers.json",
+                "schemaUrl": "https://raw.githubusercontent.com/\($repo)/\($version)/src/schema.json"
+              }
+            }')
+          for REPO in "${REPOS[@]}"; do
+            echo "Dispatching to ${REPO}"
+            gh api "repos/${REPO}/dispatches" --input - <<< "$PAYLOAD"
+          done

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           version: latest
       - name: Install
-        run: pnpm install --ignore-scripts
+        run: pnpm install --dangerously-allow-all-builds
       - name: Test
         run: pnpm test
       - name: Report

--- a/docs/dispatch/README.md
+++ b/docs/dispatch/README.md
@@ -1,0 +1,77 @@
+# Subscribe to `is-antibot` Release Dispatch Events
+
+Every time `is-antibot` runs `pnpm run release`, it sends a `repository_dispatch` event with type:
+
+`is-antibot-release-published`
+
+This guide explains how any repository can subscribe to that event.
+
+## 1. Add a Workflow in Your Repository
+
+Create `.github/workflows/is-antibot-release.yml`:
+
+```yml
+name: is-antibot release subscriber
+
+on:
+  repository_dispatch:
+    types:
+      - is-antibot-release-published
+  workflow_dispatch:
+
+jobs:
+  on-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show payload
+        run: |
+          echo "Source repository: ${{ github.event.client_payload.sourceRepository }}"
+          echo "Version: ${{ github.event.client_payload.version }}"
+          echo "Tag: ${{ github.event.client_payload.tagName }}"
+          echo "SHA: ${{ github.event.client_payload.sha }}"
+          echo "Release URL: ${{ github.event.client_payload.url }}"
+          echo "Providers URL: ${{ github.event.client_payload.providersUrl }}"
+          echo "Schema URL: ${{ github.event.client_payload.schemaUrl }}"
+
+      # Add your automation here:
+      # - sync providers JSON
+      # - run compatibility tests
+      # - open a PR
+```
+
+## 2. Register Your Repository as a Dispatch Target
+
+Since GitHub `repository_dispatch` is push-based, each receiver must be listed in the source workflow.
+
+Current receivers are defined in [`main.yml`](../../.github/workflows/main.yml) under the "Dispatch release event" step. To add a new receiver, add another dispatch step targeting your `owner/repo`.
+
+The source repo needs:
+
+- Secret: `GH_TOKEN`
+- With permission to dispatch events to the target repos.
+
+## 3. Event Payload Contract
+
+The dispatch payload includes:
+
+- `sourceRepository`: source repo (`microlinkhq/is-antibot`)
+- `version`: released version tag (for example `v1.7.0`)
+- `tagName`: same as `version`
+- `sha`: triggering commit SHA
+- `url`: GitHub release URL
+- `providersUrl`: raw URL to `src/providers.json` pinned at the release tag
+- `schemaUrl`: raw URL to `src/schema.json` pinned at the release tag
+
+## 4. Local Manual Test (Optional)
+
+You can test the subscriber workflow by dispatching manually from a token that has access to your repo:
+
+```bash
+curl -L \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/<owner>/<repo>/dispatches \
+  -d '{"event_type":"is-antibot-release-published","client_payload":{"sourceRepository":"microlinkhq/is-antibot","version":"v0.0.0","tagName":"v0.0.0","sha":"test","url":"https://github.com/microlinkhq/is-antibot/releases","providersUrl":"https://raw.githubusercontent.com/microlinkhq/is-antibot/v0.0.0/src/providers.json","schemaUrl":"https://raw.githubusercontent.com/microlinkhq/is-antibot/v0.0.0/src/schema.json"}}'
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates CI to run dependency build scripts during install and to trigger cross-repo `repository_dispatch` calls after releases; this affects pipeline security/execution and could fail or misfire if tokens/outputs are misconfigured.
> 
> **Overview**
> The CI workflows now install dependencies with `pnpm install --dangerously-allow-all-builds` (instead of `--ignore-scripts`) in both `main.yml` and `pull_request.yml`.
> 
> The `main` release job now detects whether `pnpm run release` actually bumped `package.json`’s version, and **only then** dispatches an `is-antibot-release-published` `repository_dispatch` event (including version/tag/SHA and pinned raw URLs for `providers.json`/`schema.json`) to a configured list of downstream repos.
> 
> Adds `docs/dispatch/README.md` documenting how to subscribe to the dispatch event and the expected payload contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2ad66c0a316cc98141d97cd12b343d3b9e021d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->