### PR TITLE
chore: detect amazon URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@commitlint/cli": "latest",
     "@commitlint/config-conventional": "latest",
-    "ava": "latest",
+    "ava": "7",
     "browser-sync": "latest",
     "c8": "latest",
     "ci-publish": "latest",

--- a/src/index.js
+++ b/src/index.js
@@ -176,6 +176,7 @@ const createRegExp = (pattern, flags = '') => new RegExp(pattern, flags)
 const createCompiledDetection = (detection, matches) => ({
   type: detection.type,
   domain: detection.domain,
+  domainWithoutSuffix: detection.domainWithoutSuffix,
   matches
 })
 
@@ -259,8 +260,19 @@ const DETECTION_COMPILERS = {
   }
 }
 
-const compileDetection = detection =>
-  DETECTION_COMPILERS[detection.type](detection)
+const compileDetection = detection => {
+  const compiled = DETECTION_COMPILERS[detection.type](detection)
+  const statusCodes = detection.statusCodes
+  if (!Array.isArray(statusCodes) || statusCodes.length === 0) {
+    return compiled
+  }
+  const allowed = new Set(statusCodes)
+  const innerMatches = compiled.matches
+  return {
+    ...compiled,
+    matches: context => allowed.has(context.statusCode) && innerMatches(context)
+  }
+}
 
 const compileProviders = ({ providers = [] } = {}) =>
   providers.map(provider => ({
@@ -285,7 +297,13 @@ const detectWithProviders = (
   const headerNames = getHeaderNames(headers)
   const hasUrl = Boolean(url)
 
-  let domain
+  let parsedUrl
+  const getParsedUrl = () => {
+    if (!hasUrl) return null
+    if (!parsedUrl) parsedUrl = parseUrl(url)
+    return parsedUrl
+  }
+
   const context = {
     getHeader,
     headerNames,
@@ -297,10 +315,16 @@ const detectWithProviders = (
 
   for (const provider of compiledProviders) {
     for (const detection of provider.detections) {
-      if (detection.domain) {
-        if (!hasUrl) continue
-        if (domain === undefined) domain = parseUrl(url).domain
-        if (detection.domain !== domain) continue
+      if (detection.domain || detection.domainWithoutSuffix) {
+        const parsed = getParsedUrl()
+        if (!parsed) continue
+        if (detection.domain && detection.domain !== parsed.domain) continue
+        if (
+          detection.domainWithoutSuffix &&
+          detection.domainWithoutSuffix !== parsed.domainWithoutSuffix
+        ) {
+          continue
+        }
       }
       if (!detection.matches(context)) continue
       return createResult(

--- a/src/providers.json
+++ b/src/providers.json
@@ -687,6 +687,22 @@
       ]
     },
     {
+      "name": "amazon",
+      "detections": [
+        {
+          "type": "headers",
+          "domainWithoutSuffix": "amazon",
+          "statusCodes": [500],
+          "rules": [
+            {
+              "header": "x-cache",
+              "startsWith": "Error from cloudfront"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "anubis",
       "detections": [
         {

--- a/src/schema.json
+++ b/src/schema.json
@@ -57,6 +57,18 @@
           "type": "string",
           "description": "When set, this detection only applies if the request URL's registrable domain matches (e.g. 'reddit.com')."
         },
+        "domainWithoutSuffix": {
+          "type": "string",
+          "description": "When set, this detection only applies if the request URL's registrable domain without public suffix matches (e.g. 'amazon' for amazon.es, amazon.co.uk, amazon.com)."
+        },
+        "statusCodes": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "minItems": 1,
+          "description": "When set, the detection matches only if the response status code equals one of these values (AND with the detection's rules)."
+        },
         "rules": {
           "type": "array",
           "minItems": 1,

--- a/test/index.js
+++ b/test/index.js
@@ -691,6 +691,42 @@ test('anubis (regex is case-sensitive)', t => {
   t.is(result.detected, false)
 })
 
+test('amazon (x-cache Error from cloudfront + amazon URL + status 500)', t => {
+  const result = isAntibot({
+    url: 'https://www.amazon.com/dp/B000000000',
+    headers: { 'x-cache': 'Error from cloudfront' },
+    statusCode: 500
+  })
+  t.is(result.detected, true)
+  t.is(result.provider, 'amazon')
+  t.is(result.detection, 'headers')
+})
+
+test('amazon (no match without status 500)', t => {
+  const result = isAntibot({
+    url: 'https://www.amazon.com/dp/B000000000',
+    headers: { 'x-cache': 'Error from cloudfront' },
+    statusCode: 200
+  })
+  t.is(result.detected, false)
+})
+
+test('amazon (no match when statusCode omitted)', t => {
+  const result = isAntibot({
+    url: 'https://www.amazon.com/dp/B000000000',
+    headers: { 'x-cache': 'Error from cloudfront' }
+  })
+  t.is(result.detected, false)
+})
+
+test('amazon (no false positive: CloudFront error off amazon)', t => {
+  const result = isAntibot({
+    url: 'https://example.com/',
+    headers: { 'x-cache': 'Error from cloudfront' }
+  })
+  t.is(result.detected, false)
+})
+
 test('aws-waf (header)', t => {
   const headers = { 'x-amzn-waf-action': 'CHALLENGE' }
   const result = isAntibot({ headers })

--- a/test/rule-compiler.js
+++ b/test/rule-compiler.js
@@ -71,6 +71,38 @@ test('supports cookie, contains, regex, and status operators', t => {
   t.is(detect({ statusCode: 451 }).detection, 'statusCode')
 })
 
+test('statusCodes AND-gates detection', t => {
+  const detect = createDetector({
+    providers: [
+      {
+        name: 'gated',
+        detections: [
+          {
+            type: 'headers',
+            statusCodes: [500],
+            rules: [{ header: 'x-cache', startsWith: 'Error' }]
+          }
+        ]
+      }
+    ]
+  })
+
+  t.is(
+    detect({
+      headers: { 'x-cache': 'Error from cloudfront' },
+      statusCode: 500
+    }).provider,
+    'gated'
+  )
+  t.is(
+    detect({
+      headers: { 'x-cache': 'Error from cloudfront' },
+      statusCode: 200
+    }).detected,
+    false
+  )
+})
+
 test('provider and detection order determines precedence', t => {
   const detect = createDetector({
     providers: [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core detection matching behavior by adding new gating/URL-parsing conditions, which could alter detection outcomes across providers if misconfigured. Covered by new unit tests, but still affects the main runtime path.
> 
> **Overview**
> Adds two new optional detection constraints: `domainWithoutSuffix` (match registrable domain without public suffix) and `statusCodes` (AND-gate existing detection rules by allowed HTTP statuses), updating both `src/index.js` compilation/matching logic and `src/schema.json`.
> 
> Introduces a new `amazon` provider detection that triggers on `x-cache: Error from cloudfront` for Amazon domains only when the response status is 500, with new tests covering the positive case and several non-matching scenarios. Also pins `ava` to major version `7` instead of `latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ba0650b96b22cfeedbb298ef881054b1b2f255c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->