### PR TITLE
chore(amazon): detect csm-captcha-instrumentation

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -699,6 +699,15 @@
               "startsWith": "Error from cloudfront"
             }
           ]
+        },
+        {
+          "type": "html",
+          "domainWithoutSuffix": "amazon",
+          "rules": [
+            {
+              "contains": "csm-captcha-instrumentation"
+            }
+          ]
         }
       ]
     },

--- a/test/index.js
+++ b/test/index.js
@@ -719,6 +719,26 @@ test('amazon (no match when statusCode omitted)', t => {
   t.is(result.detected, false)
 })
 
+test('amazon (captcha page with csm-captcha-instrumentation)', t => {
+  const result = isAntibot({
+    url: 'https://www.amazon.es/-/en/Earpads-Earbuds/dp/B0FSKMP53K',
+    html: '<script src="https://images-eu.ssl-images-amazon.com/images/G/01/csminstrumentation/csm-captcha-instrumentation.min.js"></script>',
+    statusCode: 200
+  })
+  t.is(result.detected, true)
+  t.is(result.provider, 'amazon')
+  t.is(result.detection, 'html')
+})
+
+test('amazon (csm-captcha-instrumentation on non-amazon URL should not match)', t => {
+  const result = isAntibot({
+    url: 'https://example.com/page',
+    html: '<script src="https://images-eu.ssl-images-amazon.com/images/G/01/csminstrumentation/csm-captcha-instrumentation.min.js"></script>',
+    statusCode: 200
+  })
+  t.is(result.detected, false)
+})
+
 test('amazon (no false positive: CloudFront error off amazon)', t => {
   const result = isAntibot({
     url: 'https://example.com/',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new Amazon-specific HTML substring check and accompanying tests, without altering core detection/normalization logic.
> 
> **Overview**
> Adds a new **Amazon** detection that flags responses as antibot when the HTML contains `csm-captcha-instrumentation`, scoped to `domainWithoutSuffix: "amazon"`.
> 
> Extends the test suite with coverage for the new captcha-page match and a regression check to prevent false positives on non-Amazon URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fcfe6d41606545967861cc79e6cfaddf5e63ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->