### PR TITLE
perf: use indexOf

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,9 +31,9 @@ const createTestPattern = value => {
       }
     }
     if (pattern && pattern.type === 'contains') {
-      return lowerValue.includes(pattern.value)
+      return lowerValue.indexOf(pattern.value) !== -1
     }
-    return lowerValue.includes(pattern.toLowerCase())
+    return lowerValue.indexOf(pattern.toLowerCase()) !== -1
   }
 }
 
@@ -43,9 +43,9 @@ const createCompiledTestPattern = value => {
   return pattern => {
     if (pattern instanceof RegExp) return pattern.test(value)
     if (pattern && pattern.type === 'contains') {
-      return lowerValue.includes(pattern.value)
+      return lowerValue.indexOf(pattern.value) !== -1
     }
-    return lowerValue.includes(pattern.toLowerCase())
+    return lowerValue.indexOf(pattern.toLowerCase()) !== -1
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk perf tweak: swaps `String.prototype.includes` for `indexOf(...) !== -1` in text pattern matching, with no behavioral intent changes beyond potential edge-case differences on unusual inputs.
> 
> **Overview**
> Replaces `includes` with `indexOf(...) !== -1` in `createTestPattern` and `createCompiledTestPattern` when evaluating `contains` rules and plain string patterns, aiming for a small performance improvement in substring checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 757bbf60cb270b14a0061900915931378bb38aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->