### PR TITLE
chore: detect FullStory client challenge (scribd.com)

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -742,6 +742,30 @@
       ]
     },
     {
+      "name": "fullstory-challenge",
+      "detections": [
+        {
+          "type": "html",
+          "rules": [
+            {
+              "contains": "Client Challenge"
+            },
+            {
+              "contains": "_fs-ch-"
+            }
+          ]
+        },
+        {
+          "type": "cookies",
+          "rules": [
+            {
+              "cookie": "_fs_ch_st_"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "aws-waf",
       "detections": [
         {

--- a/src/providers.json
+++ b/src/providers.json
@@ -748,9 +748,6 @@
           "type": "html",
           "rules": [
             {
-              "contains": "Client Challenge"
-            },
-            {
               "contains": "_fs-ch-"
             }
           ]

--- a/test/index.js
+++ b/test/index.js
@@ -747,6 +747,34 @@ test('amazon (no false positive: CloudFront error off amazon)', t => {
   t.is(result.detected, false)
 })
 
+test('fullstory-challenge (html Client Challenge title)', t => {
+  const html =
+    '<title>Client Challenge</title><script src="/_fs-ch-1T1wmsGaOgGaSxcX/assets/challenge.js"></script>'
+  const result = isAntibot({ html })
+  t.is(result.detected, true)
+  t.is(result.provider, 'fullstory-challenge')
+  t.is(result.detection, 'html')
+})
+
+test('fullstory-challenge (html _fs-ch- path)', t => {
+  const html =
+    '<link href="/_fs-ch-1T1wmsGaOgGaSxcX/assets/styles.css" rel="stylesheet" />'
+  const result = isAntibot({ html })
+  t.is(result.detected, true)
+  t.is(result.provider, 'fullstory-challenge')
+  t.is(result.detection, 'html')
+})
+
+test('fullstory-challenge (cookie)', t => {
+  const headers = {
+    'set-cookie': '_fs_ch_st_FSBmUei20MqUiJb9=Aa-8rem4vo; Path=/'
+  }
+  const result = isAntibot({ headers })
+  t.is(result.detected, true)
+  t.is(result.provider, 'fullstory-challenge')
+  t.is(result.detection, 'cookies')
+})
+
 test('aws-waf (header)', t => {
   const headers = { 'x-amzn-waf-action': 'CHALLENGE' }
   const result = isAntibot({ headers })

--- a/test/index.js
+++ b/test/index.js
@@ -747,18 +747,9 @@ test('amazon (no false positive: CloudFront error off amazon)', t => {
   t.is(result.detected, false)
 })
 
-test('fullstory-challenge (html Client Challenge title)', t => {
+test('fullstory-challenge (html _fs-ch- asset path)', t => {
   const html =
-    '<title>Client Challenge</title><script src="/_fs-ch-1T1wmsGaOgGaSxcX/assets/challenge.js"></script>'
-  const result = isAntibot({ html })
-  t.is(result.detected, true)
-  t.is(result.provider, 'fullstory-challenge')
-  t.is(result.detection, 'html')
-})
-
-test('fullstory-challenge (html _fs-ch- path)', t => {
-  const html =
-    '<link href="/_fs-ch-1T1wmsGaOgGaSxcX/assets/styles.css" rel="stylesheet" />'
+    '<title>Client Challenge</title><link href="/_fs-ch-1T1wmsGaOgGaSxcX/assets/styles.css" rel="stylesheet" />'
   const result = isAntibot({ html })
   t.is(result.detected, true)
   t.is(result.provider, 'fullstory-challenge')
@@ -773,6 +764,12 @@ test('fullstory-challenge (cookie)', t => {
   t.is(result.detected, true)
   t.is(result.provider, 'fullstory-challenge')
   t.is(result.detection, 'cookies')
+})
+
+test('fullstory-challenge (no false positive for Client Challenge without _fs-ch-)', t => {
+  const html = '<h1>Client Challenge Management Portal</h1>'
+  const result = isAntibot({ html })
+  t.is(result.detected, false)
 })
 
 test('aws-waf (header)', t => {


### PR DESCRIPTION
FullStory's _fs-ch- challenge blocks headless browsers with a JS challenge page titled "Client Challenge". Detects via HTML content and _fs_ch_st_ cookie.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider rules and tests only; no changes to core detection logic.
> 
> **Overview**
> Adds a **`fullstory-challenge`** antibot provider so FullStory’s JS “Client Challenge” (e.g. on scribd.com) can be recognized.
> 
> Detection is wired like other providers: HTML must include the **`_fs-ch-`** asset path, or **`Set-Cookie`** must mention **`_fs_ch_st_`**. Tests assert both signals and that a page titled “Client Challenge” without **`_fs-ch-`** does not match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6092642137b4a29ab95a7effa05f1f9c0131c3c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->