### PR TITLE
chore(reddit): check status code

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -411,6 +411,7 @@
         },
         {
           "type": "html",
+          "statusCodes": [403, 429, 503],
           "rules": [
             {
               "contains": "g-recaptcha"

--- a/test/index.js
+++ b/test/index.js
@@ -355,9 +355,29 @@ test('recaptcha (no false positive for grecaptcha badge css)', t => {
   t.is(result.provider, null)
 })
 
-test('recaptcha (html g-recaptcha)', t => {
+test('recaptcha (html g-recaptcha on a blocking status)', t => {
   const html = '<div class="g-recaptcha" data-sitekey="test"></div>'
-  const result = isAntibot({ html })
+  for (const statusCode of [403, 429, 503]) {
+    const result = isAntibot({ html, statusCode })
+    t.is(result.detected, true, `should detect for status ${statusCode}`)
+    t.is(result.provider, 'recaptcha')
+  }
+})
+
+test('recaptcha (no false positive: g-recaptcha widget on a 200 content page)', t => {
+  // Sites embed a reCAPTCHA login/contact widget on fully-rendered content pages; the bare
+  // widget alone (status 200) is not a block — only a blocking status or active grecaptcha is.
+  const html =
+    '<html><body><article>real content</article><div class="c-form-group g-recaptcha" data-sitekey="k"></div></body></html>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
+})
+
+test('recaptcha (html active grecaptcha on a 200 page is still a block)', t => {
+  const html =
+    '<div class="g-recaptcha"></div><script>grecaptcha.render("x")</script>'
+  const result = isAntibot({ html, statusCode: 200 })
   t.is(result.detected, true)
   t.is(result.provider, 'recaptcha')
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrower detection rules in provider config with added regression tests; no auth or infrastructure changes.
> 
> **Overview**
> Tightens **reCAPTCHA** detection so a bare `g-recaptcha` widget in HTML no longer counts as a bot block on **HTTP 200** responses.
> 
> The `g-recaptcha` HTML rule in `providers.json` now only applies when the status is **403**, **429**, or **503** (same pattern as Amazon’s status-gated rules). **Active** `grecaptcha` usage (e.g. `grecaptcha.render`) is unchanged and still flags on 200 via the existing regex rules.
> 
> Tests were updated to cover blocking statuses, the 200 false-positive case, and that active `grecaptcha` on 200 still detects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4753a7c16610183fef7b36fbd82512820f971e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->