### PR TITLE
fix(akami): remove false positive

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -49,10 +49,6 @@
               "startsWith": "Error"
             },
             {
-              "header": "akamai-grn",
-              "exists": true
-            },
-            {
               "header": "x-akamai-session-info",
               "exists": true
             }

--- a/test/index.js
+++ b/test/index.js
@@ -34,11 +34,15 @@ test('akamai (akamai-cache-status error)', t => {
   t.is(result.provider, 'akamai')
 })
 
-test('akamai (akamai-grn header)', t => {
+test('akamai (akamai-grn header alone is not antibot)', t => {
+  // akamai-grn is a per-request CDN trace id present on every Akamai-fronted
+  // response; on its own it is not a bot challenge (e.g. msn.com serves full
+  // content with this header). A real signal must be present instead.
   const headers = { 'akamai-grn': 'test123' }
   const result = isAntibot({ headers })
-  t.is(result.detected, true)
-  t.is(result.provider, 'akamai')
+  t.is(result.detected, false)
+  t.is(result.provider, null)
+  t.is(result.detection, null)
 })
 
 test('akamai (_abck set-cookie)', t => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Detection-rule tweak with matching test updates; reduces false positives without changing other Akamai signals.
> 
> **Overview**
> Stops flagging normal Akamai CDN traffic as a bot challenge when only the **`akamai-grn`** header is present.
> 
> That header is removed from Akamai header rules in **`providers.json`** because it is a per-request trace id on many legitimate responses (e.g. full pages on sites like msn.com), not a challenge signal. Other Akamai detections (`akamai-cache-status` errors, `x-akamai-session-info`, `_abck`, `bmak` in HTML) are unchanged.
> 
> The Akamai test now expects **`akamai-grn` alone** not to detect antibot, with a short comment explaining why.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6950e6070009aead7ef5e37df2ece3e5ad9043a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->