### PR TITLE
fix(providers): eliminate bare vendor-word html false positives

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -309,7 +309,8 @@
           "type": "html",
           "rules": [
             {
-              "contains": "ThreatMetrix"
+              "regex": "ThreatMetrix\\.\\w+\\s*\\(",
+              "flags": ""
             }
           ]
         },

--- a/src/providers.json
+++ b/src/providers.json
@@ -158,7 +158,7 @@
           "type": "html",
           "rules": [
             {
-              "contains": "shapesecurity"
+              "regex": "shapesecurity\\.\\w+\\s*\\("
             }
           ]
         }
@@ -213,10 +213,7 @@
           "type": "html",
           "rules": [
             {
-              "contains": "incapsula"
-            },
-            {
-              "contains": "imperva"
+              "regex": "(?:incapsula|imperva)\\.\\w+\\s*\\("
             }
           ]
         },
@@ -254,7 +251,7 @@
           "type": "html",
           "rules": [
             {
-              "contains": "reblaze"
+              "contains": "Protected by Reblaze"
             }
           ]
         }
@@ -296,7 +293,7 @@
           "type": "html",
           "rules": [
             {
-              "contains": "sucuri"
+              "contains": "Sucuri Website Firewall"
             }
           ]
         }
@@ -331,7 +328,7 @@
           "type": "html",
           "rules": [
             {
-              "contains": "meetrics"
+              "regex": "meetricsGlobal\\.\\w+\\s*\\("
             }
           ]
         },
@@ -464,7 +461,7 @@
               "contains": "arkoselabs.com"
             },
             {
-              "contains": "funcaptcha"
+              "regex": "funcaptcha\\.\\w+\\s*\\("
             }
           ]
         }
@@ -486,7 +483,7 @@
           "type": "html",
           "rules": [
             {
-              "contains": "geetest"
+              "regex": "geetest\\.\\w+\\s*\\("
             }
           ]
         }
@@ -783,10 +780,10 @@
           "type": "html",
           "rules": [
             {
-              "contains": "aws-waf"
+              "regex": "aws-waf\\.\\w+\\s*\\("
             },
             {
-              "contains": "awswaf"
+              "regex": "awswaf\\.com|\\/awswaf\\/"
             }
           ]
         },

--- a/test/index.js
+++ b/test/index.js
@@ -160,6 +160,12 @@ test('shapesecurity (html)', t => {
   t.is(result.provider, 'shapesecurity')
 })
 
+test('shapesecurity (no false positive for bare mention)', t => {
+  const html = '<p>shapesecurity (now F5) writeup</p>'
+  const result = isAntibot({ html })
+  t.is(result.detected, false)
+})
+
 test('kasada (header)', t => {
   const headers = { 'x-kasada': 'test' }
   const result = isAntibot({ headers })
@@ -193,6 +199,13 @@ test('imperva (html with imperva)', t => {
   const result = isAntibot({ html })
   t.is(result.detected, true)
   t.is(result.provider, 'imperva')
+})
+
+test('imperva (no false positive for bare mention)', t => {
+  const html =
+    '<footer>Security powered by Imperva</footer><p>We migrated from Incapsula.</p>'
+  const result = isAntibot({ html })
+  t.is(result.detected, false)
 })
 
 test('imperva (incap_ses_ set-cookie)', t => {
@@ -238,6 +251,12 @@ test('reblaze (html)', t => {
   t.is(result.detection, 'html')
 })
 
+test('reblaze (no false positive for bare mention)', t => {
+  const html = '<p>Reblaze vs Cloudflare comparison</p>'
+  const result = isAntibot({ html })
+  t.is(result.detected, false)
+})
+
 test('cheq (html CheqSdk)', t => {
   const html = '<script>CheqSdk.init();</script>'
   const result = isAntibot({ html })
@@ -272,6 +291,12 @@ test('sucuri (html)', t => {
   const result = isAntibot({ html })
   t.is(result.detected, true)
   t.is(result.provider, 'sucuri')
+})
+
+test('sucuri (no false positive for badge / bare mention)', t => {
+  const html = '<a href="https://sitecheck.sucuri.net/">Scanned by Sucuri</a>'
+  const result = isAntibot({ html })
+  t.is(result.detected, false)
 })
 
 test('threatmetrix (html)', t => {
@@ -310,6 +335,13 @@ test('meetrics (url)', t => {
   const result = isAntibot({ url })
   t.is(result.detected, true)
   t.is(result.provider, 'meetrics')
+})
+
+test('meetrics (no false positive for bare mention)', t => {
+  const html =
+    '<script>var x={"vendor":"meetrics"}</script><h1>Real article</h1>'
+  const result = isAntibot({ html })
+  t.is(result.detected, false)
 })
 
 test('ocule (html)', t => {
@@ -444,6 +476,12 @@ test('funcaptcha (html with funcaptcha)', t => {
   t.is(result.provider, 'funcaptcha')
 })
 
+test('funcaptcha (no false positive for bare funcaptcha mention)', t => {
+  const html = '<p>funcaptcha is now called Arkose.</p>'
+  const result = isAntibot({ html })
+  t.is(result.detected, false)
+})
+
 test('funcaptcha (html with arkoselabs.com)', t => {
   const html =
     '<script src="https://client-api.arkoselabs.com/fc/assets/loader.js"></script>'
@@ -475,6 +513,12 @@ test('geetest (html)', t => {
 
 test('geetest (no false positive for generic gt.js)', t => {
   const html = '<script src="/static/gt.js"></script>'
+  const result = isAntibot({ html })
+  t.is(result.detected, false)
+})
+
+test('geetest (no false positive for bare mention)', t => {
+  const html = '<p>We evaluated geetest for our login.</p>'
   const result = isAntibot({ html })
   t.is(result.detected, false)
 })
@@ -872,6 +916,12 @@ test('aws-waf (html awswaf)', t => {
   const result = isAntibot({ html })
   t.is(result.detected, true)
   t.is(result.provider, 'aws-waf')
+})
+
+test('aws-waf (no false positive for bare mention)', t => {
+  const html = '<p>How to configure aws-waf rules in awswaf docs</p>'
+  const result = isAntibot({ html })
+  t.is(result.detected, false)
 })
 
 test('aws-waf (aws-waf-token set-cookie)', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -288,6 +288,16 @@ test('threatmetrix (url fp/check.js)', t => {
   t.is(result.provider, 'threatmetrix')
 })
 
+test('threatmetrix (html, not a false positive on config keys)', t => {
+  // Netflix embeds feature-flag config keys mentioning threatmetrix in the page
+  // JSON. These are not an antibot challenge: the device-profiling tag is only
+  // active when the ThreatMetrix JS API is invoked (e.g. ThreatMetrix.init()).
+  const html =
+    '{"enable.threatmetrix.debug":true,"enable.threatmetrix.onload.timeout":6000}'
+  const result = isAntibot({ html })
+  t.is(result.detected, false)
+})
+
 test('meetrics (html)', t => {
   const html = '<script>meetricsGlobal.init();</script>'
   const result = isAntibot({ html })


### PR DESCRIPTION
## Problem

Several HTML detection rules matched a **bare vendor name** via case-insensitive substring. These fired on fully-rendered `200` pages that merely *mention* or *integrate* a vendor — config keys, security badges, comparison articles — not on an actual challenge, surfacing downstream as spurious antibot upgrade prompts (`EPROXYNEEDED`).

The original report: `https://www.netflix.com/es-en/title/80057281` returns a normal 1.1 MB page whose JSON includes `"enable.threatmetrix.debug":true`, which tripped the `threatmetrix` rule `{ "contains": "ThreatMetrix" }`.

An audit found the same class of bug in 7 more providers.

## Fix

Each rule is tightened to its **active** signal — matching the existing positive test fixtures and the pattern already used by `recaptcha`/`hcaptcha`/`cloudflare-turnstile`:

| Provider | Before | After (active signal) |
|---|---|---|
| threatmetrix | `contains "ThreatMetrix"` | `regex ThreatMetrix\.\w+\s*\(` (JS API) |
| shapesecurity | `contains "shapesecurity"` | `regex shapesecurity\.\w+\s*\(` |
| imperva | `contains "incapsula"`/`"imperva"` | `regex (?:incapsula\|imperva)\.\w+\s*\(` |
| meetrics | `contains "meetrics"` | `regex meetricsGlobal\.\w+\s*\(` |
| geetest | `contains "geetest"` | `regex geetest\.\w+\s*\(` |
| funcaptcha | `contains "funcaptcha"` | `regex funcaptcha\.\w+\s*\(` (kept `arkoselabs.com`) |
| sucuri | `contains "sucuri"` | `contains "Sucuri Website Firewall"` (block page) |
| reblaze | `contains "reblaze"` | `contains "Protected by Reblaze"` (block page) |
| aws-waf | `contains "aws-waf"`/`"awswaf"` | `regex aws-waf\.\w+\s*\(` + `regex awswaf\.com\|/awswaf/` |

Header/cookie/URL detections are untouched, so real challenges (e.g. Imperva `incap_ses_` cookie, AWS WAF `x-amzn-waf-action` header) remain detected.

## Tests

- All existing positive fixtures still pass
- Added a bare-mention regression test per provider (9 total)
- Full suite: **130 passing**

Verified end-to-end against the api: the Netflix screenshot request now returns `status: success` with metadata + screenshot on the free plan (was `EPROXYNEEDED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad behavior change to live detection rules may miss rare pages that only signaled via bare text, but scope is heuristic tuning in providers.json with regression coverage rather than core runtime logic.
> 
> **Overview**
> Tightens **HTML detection heuristics** in `providers.json` so normal pages are less often flagged as antibot when a vendor name only appears in copy, badges, or embedded config JSON.
> 
> Several providers move from case-insensitive **`contains`** substring checks to **JS API–style `regex`** patterns (e.g. `ThreatMetrix.\w+\s*(`, `shapesecurity.\w+\s*(`, `funcaptcha.\w+\s*(`, `geetest.\w+\s*(`, `meetricsGlobal.\w+\s*(`, `aws-waf.\w+\s*(`). **Imperva** consolidates separate `incapsula` / `imperva` contains rules into one regex for `incapsula|imperva` API calls. **Reblaze** and **Sucuri** use more specific **contains** strings (`Protected by Reblaze`, `Sucuri Website Firewall`). **AWS WAF** also distinguishes real challenge assets via `awswaf.com` or `/awswaf/` paths instead of a bare `awswaf` mention.
> 
> **ThreatMetrix** is the motivating fix: case-sensitive API invocation matching avoids hits on lowercase feature-flag keys like `enable.threatmetrix.debug` on otherwise normal `200` pages; the `fp/check.js` URL rule is unchanged.
> 
> Regression tests in `test/index.js` assert bare mentions, badges, and config-key JSON no longer trigger detection while existing positive cases (e.g. `*.init()`) still pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91969a962d25a6fe750a76686cf67e74c4421c2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->