### PR TITLE
feat(houzz): detect datacenter 429 rate-limit block

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -612,6 +612,20 @@
       ]
     },
     {
+      "name": "houzz",
+      "detections": [
+        {
+          "type": "status_code",
+          "domain": "houzz.com",
+          "rules": [
+            {
+              "status": 429
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "reddit",
       "detections": [
         {

--- a/test/index.js
+++ b/test/index.js
@@ -628,6 +628,39 @@ test('aliexpress-captcha (html)', t => {
   t.is(result.provider, 'aliexpress-captcha')
 })
 
+test('houzz (blocked by status code)', t => {
+  // Houzz rate-limits datacenter IPs with a bare 429 "too many requests" page
+  // that carries no antibot fingerprint. Scope the status rule to the domain so
+  // an origin fetch surfacing a 429 escalates to the residential proxy.
+  const url =
+    'https://www.houzz.com/photos/primary-bathroom-retreat-transitional-bathroom-london-phvw-vp~210219633'
+  const html = '<html><body>\n429 Error too many requests \n</body></html>'
+  const result = isAntibot({ url, html, statusCode: 429 })
+  t.is(result.detected, true)
+  t.is(result.provider, 'houzz')
+  t.is(result.detection, 'statusCode')
+})
+
+test('houzz (429 on non-houzz url should not match)', t => {
+  const result = isAntibot({
+    url: 'https://example.com/some/path',
+    statusCode: 429
+  })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
+})
+
+test('houzz (200 on houzz url should not match)', t => {
+  const url = 'https://www.houzz.com/photos/x~210219633'
+  const result = isAntibot({
+    url,
+    html: '<html><body>ok</body></html>',
+    statusCode: 200
+  })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
+})
+
 test('reddit (blocked html)', t => {
   const html = '<div>blocked by network security.</div>'
   const url =


### PR DESCRIPTION
Houzz rate-limits datacenter IPs with a bare HTTP 429 "too many requests" page that carries no antibot fingerprint (no _fs-ch- marker, empty headers), so is-antibot could not flag it and the API never escalated to the residential proxy. Add a domain-scoped status_code rule (mirroring reddit) so a 429 from houzz.com is treated as a block and triggers proxy discovery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only provider entry and tests using an established domain-scoped status_code pattern; no runtime logic changes.
> 
> **Overview**
> Adds a **houzz** provider so bare HTTP **429** responses from **houzz.com** count as antibot blocks, matching the domain-scoped **status_code** pattern used for reddit and dribbble.
> 
> Houzz’s datacenter rate limit returns a minimal “too many requests” page with no captcha or `_fs-ch-` markers, so fetches were not flagged and downstream logic did not escalate to a residential proxy. The rule only fires when the URL’s domain is `houzz.com` and the status is 429.
> 
> Tests cover a positive Houzz 429 case and guardrails: 429 on other hosts and 200 on Houzz do not match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1f505dc83e8b6cb3e357e8b9e4675405566f353. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->