### PR TITLE
fix(cloudflare): detect Just a moment interstitial

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -31,6 +31,15 @@
               "contains": "_cf_chl_opt"
             }
           ]
+        },
+        {
+          "type": "html",
+          "statusCodes": [403, 503],
+          "rules": [
+            {
+              "contains": "<title>Just a moment...</title>"
+            }
+          ]
         }
       ]
     },

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,19 @@ test('cloudflare (html _cf_chl_opt interstitial)', t => {
   t.is(result.detection, 'html')
 })
 
+test('cloudflare (html Just a moment title on 403)', t => {
+  const html = '<title>Just a moment...</title>'
+  const result = isAntibot({ html, statusCode: 403 })
+  t.is(result.detected, true)
+  t.is(result.provider, 'cloudflare')
+  t.is(result.detection, 'html')
+})
+
+test('cloudflare (no false positive for Just a moment title on 200)', t => {
+  const html = '<title>Just a moment...</title>'
+  t.is(isAntibot({ html, statusCode: 200 }).detected, false)
+})
+
 test('cloudflare (no false positive for jsd beacon)', t => {
   const html =
     "<script>window.__CF$cv$params={r:'abc'};a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';</script>"

--- a/test/index.js
+++ b/test/index.js
@@ -28,16 +28,14 @@ test('cloudflare (html _cf_chl_opt interstitial)', t => {
   t.is(result.detection, 'html')
 })
 
-test('cloudflare (html Just a moment title on 403)', t => {
+test('cloudflare (html Just a moment title)', t => {
   const html = '<title>Just a moment...</title>'
-  const result = isAntibot({ html, statusCode: 403 })
-  t.is(result.detected, true)
-  t.is(result.provider, 'cloudflare')
-  t.is(result.detection, 'html')
-})
-
-test('cloudflare (no false positive for Just a moment title on 200)', t => {
-  const html = '<title>Just a moment...</title>'
+  for (const statusCode of [403, 503]) {
+    const result = isAntibot({ html, statusCode })
+    t.is(result.detected, true)
+    t.is(result.provider, 'cloudflare')
+    t.is(result.detection, 'html')
+  }
   t.is(isAntibot({ html, statusCode: 200 }).detected, false)
 })
 


### PR DESCRIPTION
## Summary
- Cloudflare managed challenges sometimes reach `is-antibot` without `cf-mitigated` (prerender header objects omit it) and without `_cf_chl_opt` in the serialized HTML.
- Match `<title>Just a moment...</title>` on 403/503 only, so JSD beacons on successful 200s stay clean.

## Test plan
- [x] `pnpm test` (hit on 403 + FP on 200)
- [ ] Confirm investopedia.com 403 interstitial is detected from HTML alone


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Cloudflare challenge pages when responses return HTTP 403 or 503 errors.
  * Avoids incorrectly flagging normal HTTP 200 responses containing similar page titles as antibot activity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->