### PR TITLE
feat: return challenge technique on each detection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,7 @@ import isAntibot from 'is-antibot'
 
 const response = await fetch('https://example.com')
 
-const { detected, provider, detection } = isAntibot({
+const { detected, provider, detection, technique } = isAntibot({
   headers: response.headers,
   statusCode: response.status,
   html: await response.text(),
@@ -96,8 +96,8 @@ const { detected, provider, detection } = isAntibot({
 })
 
 if (detected) {
-  console.log(`Blocked by ${provider} (via ${detection})`)
-  // => "Blocked by CloudFlare (via headers)"
+  console.log(`Blocked by ${provider} (via ${detection}, ${technique})`)
+  // => "Blocked by CloudFlare (via headers, javascript)"
 }
 ```
 
@@ -114,7 +114,7 @@ At a high level, **is-antibot** classifies challenge responses using:
 - **Response headers and body markers**: Blocking responses usually expose hints in headers and HTML, such as mitigation headers, challenge tokens, or provider-specific script references.
 - **Provider-specific fingerprints**: Each provider leaves a distinct combination of signals; for example, Cloudflare commonly surfaces `cf-mitigated: challenge`, while other providers rely more on cookie, URL, or HTML fingerprints.
 
-Each provider has unique fingerprints across one or more of these signals. The library checks them in priority order and returns the first match.
+Each provider has unique fingerprints across one or more of these signals. The library checks them in priority order and returns the first match, including a `technique` (`javascript`, `captcha`, `waf`, or `cookie`) so callers can choose a retry strategy.
 
 ## Providers
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,7 +97,7 @@ const { detected, provider, detection, technique } = isAntibot({
 
 if (detected) {
   console.log(`Blocked by ${provider} (via ${detection}, ${technique})`)
-  // => "Blocked by CloudFlare (via headers, javascript)"
+  // => "Blocked by cloudflare (via headers, javascript)"
 }
 ```
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -40,7 +40,7 @@ Key capabilities:
 
 - zero configuration, works with any HTTP client (fetch, got, axios, undici)
 - lightweight with only 3 dependencies
-- returns provider name and detection signal for programmatic routing
+- returns provider name, detection signal, and technique (`javascript`, `captcha`, `waf`, `cookie`) for programmatic routing
 
 Primary page:
 

--- a/examples/fetch.mjs
+++ b/examples/fetch.mjs
@@ -4,7 +4,7 @@ const response = await fetch('https://www.linkedin.com/in/kikobeats/')
 
 const { headers, status: statusCode, url } = response
 
-const { detected, provider, detection } = isAntibot({
+const { detected, provider, detection, technique } = isAntibot({
   headers,
   statusCode,
   html: await response.text(),
@@ -12,6 +12,6 @@ const { detected, provider, detection } = isAntibot({
 })
 
 if (detected) {
-  console.log(`Blocked by ${provider} (via ${detection})`)
-  // => "Blocked by LinkedIn (via headers)"
+  console.log(`Blocked by ${provider} (via ${detection}, ${technique})`)
+  // => "Blocked by LinkedIn (via statusCode, waf)"
 }

--- a/examples/fetch.mjs
+++ b/examples/fetch.mjs
@@ -13,5 +13,5 @@ const { detected, provider, detection, technique } = isAntibot({
 
 if (detected) {
   console.log(`Blocked by ${provider} (via ${detection}, ${technique})`)
-  // => "Blocked by LinkedIn (via statusCode, waf)"
+  // => "Blocked by linkedin (via statusCode, waf)"
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "description": "Detect antibot protection from 30+ providers — Cloudflare, Akamai, DataDome, PerimeterX, and more.",
   "homepage": "https://antibot.microlink.io/",
   "version": "2.3.5",
+  "types": "./src/index.d.ts",
   "exports": {
-    ".": "./src/index.js",
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    },
     "./providers.json": "./src/providers.json",
     "./schema.json": "./src/schema.json",
     "./providers.schema.json": "./src/schema.json"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,110 @@
+type HeadersLike =
+  | { get(name: string): string | null | undefined }
+  | Record<string, string | string[] | undefined>
+
+declare namespace isAntibot {
+  type Detection = 'headers' | 'cookies' | 'html' | 'url' | 'statusCode'
+  type Technique = 'javascript' | 'captcha' | 'waf' | 'cookie'
+  type ProviderName =
+    | 'cloudflare'
+    | 'vercel'
+    | 'akamai'
+    | 'datadome'
+    | 'perimeterx'
+    | 'shapesecurity'
+    | 'kasada'
+    | 'imperva'
+    | 'reblaze'
+    | 'cheq'
+    | 'sucuri'
+    | 'threatmetrix'
+    | 'meetrics'
+    | 'ocule'
+    | 'recaptcha'
+    | 'hcaptcha'
+    | 'funcaptcha'
+    | 'geetest'
+    | 'cloudflare-turnstile'
+    | 'friendly-captcha'
+    | 'captcha-eu'
+    | 'qcloud-captcha'
+    | 'aliexpress-captcha'
+    | 'houzz'
+    | 'reddit'
+    | 'google'
+    | 'linkedin'
+    | 'instagram'
+    | 'youtube'
+    | 'amazon'
+    | 'anubis'
+    | 'fullstory-challenge'
+    | 'aws-waf'
+    | 'weibo'
+    | 'dribbble'
+    | 'douban'
+
+  interface Input {
+    headers?: HeadersLike
+    html?: string
+    body?: string
+    url?: string
+    statusCode?: number
+    status?: number
+  }
+
+  interface Result {
+    detected: boolean
+    provider: ProviderName | string | null
+    detection: Detection | null
+    technique: Technique | null
+  }
+
+  type DetectionRule =
+    | { header: string; equals: string }
+    | { header: string; startsWith: string }
+    | { header: string; exists: true; except?: string }
+    | { header: string; oneOf: string[] }
+    | { headerNamePattern: string; flags?: string }
+    | { cookie: string }
+    | { contains: string }
+    | { regex: string; flags?: string }
+    | { status: number }
+
+  interface DetectorDetection {
+    type: 'headers' | 'cookies' | 'html' | 'url' | 'status_code'
+    technique?: Technique
+    domain?: string
+    domainWithoutSuffix?: string
+    statusCodes?: number[]
+    rules: DetectionRule[]
+  }
+
+  interface DetectorProvider {
+    name: string
+    detections: DetectorDetection[]
+  }
+
+  function createDetector(config?: {
+    providers?: DetectorProvider[]
+  }): (input?: Input) => Result
+
+  function createHasCookie(
+    headers: HeadersLike,
+    getHeader?: (name: string) => string | string[] | null | undefined
+  ): (patternList: string | readonly string[]) => boolean
+
+  function createTestPattern(
+    value?: string | null
+  ): (
+    pattern: string | RegExp | { type: 'contains'; value: string }
+  ) => boolean
+
+  const debug: {
+    (...args: unknown[]): void
+    [level: string]: (...args: unknown[]) => void
+  }
+}
+
+declare function isAntibot(input?: isAntibot.Input): isAntibot.Result
+
+export = isAntibot

--- a/src/index.js
+++ b/src/index.js
@@ -49,9 +49,14 @@ const createCompiledTestPattern = value => {
   }
 }
 
-const createResult = (detected, provider, detection = null) => {
-  debug({ detected, provider, detection })
-  return { detected, provider, detection }
+const createResult = (
+  detected,
+  provider,
+  detection = null,
+  technique = null
+) => {
+  debug({ detected, provider, detection, technique })
+  return { detected, provider, detection, technique }
 }
 
 const compileCookieMatcher = patternList => {
@@ -175,6 +180,7 @@ const createRegExp = (pattern, flags = '') => new RegExp(pattern, flags)
 
 const createCompiledDetection = (detection, matches) => ({
   type: detection.type,
+  technique: detection.technique ?? null,
   domain: detection.domain,
   domainWithoutSuffix: detection.domainWithoutSuffix,
   matches
@@ -330,7 +336,8 @@ const detectWithProviders = (
       return createResult(
         true,
         provider.name,
-        DETECTION[detection.type] || detection.type
+        DETECTION[detection.type] || detection.type,
+        detection.technique
       )
     }
   }

--- a/src/providers.json
+++ b/src/providers.json
@@ -9,6 +9,7 @@
       "detections": [
         {
           "type": "headers",
+          "technique": "javascript",
           "rules": [
             {
               "header": "cf-mitigated",
@@ -18,6 +19,7 @@
         },
         {
           "type": "cookies",
+          "technique": "cookie",
           "rules": [
             {
               "cookie": "cf_clearance="
@@ -26,6 +28,7 @@
         },
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "contains": "_cf_chl_opt"
@@ -41,6 +44,7 @@
       "detections": [
         {
           "type": "headers",
+          "technique": "javascript",
           "rules": [
             {
               "header": "x-vercel-mitigated",
@@ -57,6 +61,7 @@
       "detections": [
         {
           "type": "headers",
+          "technique": "waf",
           "rules": [
             {
               "header": "akamai-cache-status",
@@ -70,6 +75,7 @@
         },
         {
           "type": "cookies",
+          "technique": "cookie",
           "rules": [
             {
               "cookie": "_abck="
@@ -78,6 +84,7 @@
         },
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "contains": "bmak."
@@ -93,6 +100,7 @@
       "detections": [
         {
           "type": "headers",
+          "technique": "javascript",
           "rules": [
             {
               "header": "x-dd-b",
@@ -114,6 +122,7 @@
         },
         {
           "type": "cookies",
+          "technique": "cookie",
           "rules": [
             {
               "cookie": "datadome="
@@ -129,6 +138,7 @@
       "detections": [
         {
           "type": "headers",
+          "technique": "javascript",
           "rules": [
             {
               "header": "x-px-authorization",
@@ -138,6 +148,7 @@
         },
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "contains": "window._pxAppId"
@@ -152,6 +163,7 @@
         },
         {
           "type": "cookies",
+          "technique": "cookie",
           "rules": [
             {
               "cookie": "_px3="
@@ -170,6 +182,7 @@
       "detections": [
         {
           "type": "headers",
+          "technique": "waf",
           "rules": [
             {
               "headerNamePattern": "^x-[a-z0-9]{8}-[abcdfz]$",
@@ -179,6 +192,7 @@
         },
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "regex": "shapesecurity\\.\\w+\\s*\\("
@@ -194,6 +208,7 @@
       "detections": [
         {
           "type": "headers",
+          "technique": "javascript",
           "rules": [
             {
               "header": "x-kasada",
@@ -207,6 +222,7 @@
         },
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "contains": "__kasada"
@@ -225,6 +241,7 @@
       "detections": [
         {
           "type": "headers",
+          "technique": "waf",
           "rules": [
             {
               "header": "x-cdn",
@@ -238,6 +255,7 @@
         },
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "regex": "(?:incapsula|imperva)\\.\\w+\\s*\\("
@@ -246,6 +264,7 @@
         },
         {
           "type": "cookies",
+          "technique": "cookie",
           "rules": [
             {
               "cookie": "incap_ses_"
@@ -267,6 +286,7 @@
       "detections": [
         {
           "type": "cookies",
+          "technique": "cookie",
           "rules": [
             {
               "cookie": "rbzid="
@@ -278,6 +298,7 @@
         },
         {
           "type": "html",
+          "technique": "waf",
           "rules": [
             {
               "contains": "Protected by Reblaze"
@@ -293,6 +314,7 @@
       "detections": [
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "contains": "CheqSdk"
@@ -304,6 +326,7 @@
         },
         {
           "type": "url",
+          "technique": "javascript",
           "rules": [
             {
               "regex": "cheqzone\\.com",
@@ -324,6 +347,7 @@
       "detections": [
         {
           "type": "html",
+          "technique": "waf",
           "rules": [
             {
               "contains": "Sucuri Website Firewall"
@@ -339,6 +363,7 @@
       "detections": [
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "regex": "ThreatMetrix\\.\\w+\\s*\\(",
@@ -348,6 +373,7 @@
         },
         {
           "type": "url",
+          "technique": "javascript",
           "rules": [
             {
               "contains": "fp/check.js"
@@ -363,6 +389,7 @@
       "detections": [
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "regex": "meetricsGlobal\\.\\w+\\s*\\("
@@ -371,6 +398,7 @@
         },
         {
           "type": "url",
+          "technique": "javascript",
           "rules": [
             {
               "regex": "meetrics\\.com",
@@ -387,6 +415,7 @@
       "detections": [
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "contains": "ocule.co.uk"
@@ -395,6 +424,7 @@
         },
         {
           "type": "url",
+          "technique": "javascript",
           "rules": [
             {
               "regex": "ocule\\.co\\.uk",
@@ -411,6 +441,7 @@
       "detections": [
         {
           "type": "url",
+          "technique": "captcha",
           "rules": [
             {
               "contains": "recaptcha/api"
@@ -429,6 +460,7 @@
         },
         {
           "type": "html",
+          "technique": "captcha",
           "rules": [
             {
               "regex": "\\b(?:window\\.)?grecaptcha\\s*\\.(?:execute|render|ready|getResponse|enterprise)\\b",
@@ -446,6 +478,7 @@
         },
         {
           "type": "html",
+          "technique": "captcha",
           "statusCodes": [
             403,
             429,
@@ -466,6 +499,7 @@
       "detections": [
         {
           "type": "url",
+          "technique": "captcha",
           "rules": [
             {
               "regex": "hcaptcha\\.com",
@@ -475,6 +509,7 @@
         },
         {
           "type": "html",
+          "technique": "captcha",
           "rules": [
             {
               "contains": "hcaptcha.com"
@@ -493,6 +528,7 @@
       "detections": [
         {
           "type": "url",
+          "technique": "captcha",
           "rules": [
             {
               "regex": "arkoselabs\\.com",
@@ -505,6 +541,7 @@
         },
         {
           "type": "html",
+          "technique": "captcha",
           "rules": [
             {
               "contains": "arkoselabs.com"
@@ -523,6 +560,7 @@
       "detections": [
         {
           "type": "url",
+          "technique": "captcha",
           "rules": [
             {
               "regex": "geetest\\.com",
@@ -532,6 +570,7 @@
         },
         {
           "type": "html",
+          "technique": "captcha",
           "rules": [
             {
               "regex": "geetest\\.\\w+\\s*\\("
@@ -547,6 +586,7 @@
       "detections": [
         {
           "type": "url",
+          "technique": "captcha",
           "rules": [
             {
               "regex": "challenges\\.cloudflare\\.com\\/turnstile",
@@ -556,6 +596,7 @@
         },
         {
           "type": "html",
+          "technique": "captcha",
           "rules": [
             {
               "contains": "cf-turnstile"
@@ -574,6 +615,7 @@
       "detections": [
         {
           "type": "url",
+          "technique": "captcha",
           "rules": [
             {
               "regex": "friendlycaptcha\\.com",
@@ -583,6 +625,7 @@
         },
         {
           "type": "html",
+          "technique": "captcha",
           "rules": [
             {
               "contains": "frc-captcha"
@@ -601,6 +644,7 @@
       "detections": [
         {
           "type": "url",
+          "technique": "captcha",
           "rules": [
             {
               "regex": "captcha\\.eu",
@@ -610,6 +654,7 @@
         },
         {
           "type": "html",
+          "technique": "captcha",
           "rules": [
             {
               "contains": "CaptchaEU"
@@ -628,6 +673,7 @@
       "detections": [
         {
           "type": "url",
+          "technique": "captcha",
           "rules": [
             {
               "regex": "turing\\.captcha\\.qcloud\\.com",
@@ -637,6 +683,7 @@
         },
         {
           "type": "html",
+          "technique": "captcha",
           "rules": [
             {
               "contains": "TencentCaptcha"
@@ -655,6 +702,7 @@
       "detections": [
         {
           "type": "url",
+          "technique": "captcha",
           "rules": [
             {
               "regex": "punish\\?x5secdata",
@@ -664,6 +712,7 @@
         },
         {
           "type": "html",
+          "technique": "captcha",
           "rules": [
             {
               "contains": "x5secdata"
@@ -679,6 +728,7 @@
       "detections": [
         {
           "type": "status_code",
+          "technique": "waf",
           "domain": "houzz.com",
           "rules": [
             {
@@ -695,6 +745,7 @@
       "detections": [
         {
           "type": "status_code",
+          "technique": "waf",
           "domain": "reddit.com",
           "rules": [
             {
@@ -707,6 +758,7 @@
         },
         {
           "type": "html",
+          "technique": "javascript",
           "domain": "reddit.com",
           "rules": [
             {
@@ -727,6 +779,7 @@
       "detections": [
         {
           "type": "url",
+          "technique": "javascript",
           "rules": [
             {
               "contains": "consent.google.com"
@@ -742,6 +795,7 @@
       "detections": [
         {
           "type": "status_code",
+          "technique": "waf",
           "domain": "linkedin.com",
           "rules": [
             {
@@ -758,6 +812,7 @@
       "detections": [
         {
           "type": "html",
+          "technique": "javascript",
           "domain": "instagram.com",
           "rules": [
             {
@@ -775,6 +830,7 @@
       "detections": [
         {
           "type": "html",
+          "technique": "waf",
           "rules": [
             {
               "regex": "<title>\\s*-\\s*YouTube<\\/title>",
@@ -791,6 +847,7 @@
       "detections": [
         {
           "type": "headers",
+          "technique": "waf",
           "domainWithoutSuffix": "amazon",
           "statusCodes": [
             500
@@ -804,6 +861,7 @@
         },
         {
           "type": "html",
+          "technique": "captcha",
           "domainWithoutSuffix": "amazon",
           "rules": [
             {
@@ -820,6 +878,7 @@
       "detections": [
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "regex": "<script id=\"anubis_challenge\"",
@@ -839,6 +898,7 @@
       "detections": [
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "contains": "_fs-ch-"
@@ -847,6 +907,7 @@
         },
         {
           "type": "cookies",
+          "technique": "cookie",
           "rules": [
             {
               "cookie": "_fs_ch_st_"
@@ -862,6 +923,7 @@
       "detections": [
         {
           "type": "headers",
+          "technique": "waf",
           "rules": [
             {
               "header": "x-amzn-waf-action",
@@ -875,6 +937,7 @@
         },
         {
           "type": "html",
+          "technique": "javascript",
           "rules": [
             {
               "regex": "aws-waf\\.\\w+\\s*\\("
@@ -886,6 +949,7 @@
         },
         {
           "type": "cookies",
+          "technique": "cookie",
           "rules": [
             {
               "cookie": "aws-waf-token="
@@ -902,6 +966,7 @@
       "detections": [
         {
           "type": "html",
+          "technique": "javascript",
           "domainWithoutSuffix": "weibo",
           "rules": [
             {
@@ -919,6 +984,7 @@
       "detections": [
         {
           "type": "status_code",
+          "technique": "waf",
           "domain": "dribbble.com",
           "rules": [
             {
@@ -936,6 +1002,7 @@
       "detections": [
         {
           "type": "status_code",
+          "technique": "waf",
           "domain": "doubanio.com",
           "rules": [
             {

--- a/src/providers.json
+++ b/src/providers.json
@@ -182,7 +182,7 @@
       "detections": [
         {
           "type": "headers",
-          "technique": "waf",
+          "technique": "javascript",
           "rules": [
             {
               "headerNamePattern": "^x-[a-z0-9]{8}-[abcdfz]$",
@@ -923,7 +923,7 @@
       "detections": [
         {
           "type": "headers",
-          "technique": "waf",
+          "technique": "javascript",
           "rules": [
             {
               "header": "x-amzn-waf-action",

--- a/src/schema.json
+++ b/src/schema.json
@@ -56,11 +56,15 @@
     },
     "detection": {
       "type": "object",
-      "required": ["type", "rules"],
+      "required": ["type", "technique", "rules"],
       "additionalProperties": false,
       "properties": {
         "type": {
           "enum": ["headers", "cookies", "html", "url", "status_code"]
+        },
+        "technique": {
+          "enum": ["javascript", "captcha", "waf", "cookie"],
+          "description": "Challenge kind on the matching detection. javascript: JS interstitial that needs a browser. captcha: interactive widget. waf: network/status/IP block. cookie: vendor cookie (may be leftover on success)."
         },
         "domain": {
           "type": "string",

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ test('cloudflare (cf-mitigated header)', t => {
   t.is(result.detected, true)
   t.is(result.provider, 'cloudflare')
   t.is(result.detection, 'headers')
+  t.is(result.technique, 'javascript')
 })
 
 test('cloudflare (cf_clearance set-cookie)', t => {
@@ -18,6 +19,7 @@ test('cloudflare (cf_clearance set-cookie)', t => {
   t.is(result.detected, true)
   t.is(result.provider, 'cloudflare')
   t.is(result.detection, 'cookies')
+  t.is(result.technique, 'cookie')
 })
 
 test('cloudflare (html _cf_chl_opt interstitial)', t => {
@@ -26,6 +28,7 @@ test('cloudflare (html _cf_chl_opt interstitial)', t => {
   t.is(result.detected, true)
   t.is(result.provider, 'cloudflare')
   t.is(result.detection, 'html')
+  t.is(result.technique, 'javascript')
 })
 
 test('cloudflare (no false positive for jsd beacon)', t => {
@@ -418,6 +421,7 @@ test('recaptcha (html grecaptcha)', t => {
   const result = isAntibot({ html })
   t.is(result.detected, true)
   t.is(result.provider, 'recaptcha')
+  t.is(result.technique, 'captcha')
 })
 
 test('recaptcha (no false positive for grecaptcha badge css)', t => {
@@ -666,6 +670,7 @@ test('houzz (blocked by status code)', t => {
   t.is(result.detected, true)
   t.is(result.provider, 'houzz')
   t.is(result.detection, 'statusCode')
+  t.is(result.technique, 'waf')
 })
 
 test('houzz (429 on non-houzz url should not match)', t => {
@@ -1014,6 +1019,8 @@ test('no headers provided', t => {
   const result = isAntibot()
   t.is(result.detected, false)
   t.is(result.provider, null)
+  t.is(result.detection, null)
+  t.is(result.technique, null)
 })
 
 test('support Headers object', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -181,6 +181,7 @@ test('shapesecurity (header)', t => {
   const result = isAntibot({ headers })
   t.is(result.detected, true)
   t.is(result.provider, 'shapesecurity')
+  t.is(result.technique, 'javascript')
 })
 
 test('shapesecurity (html)', t => {
@@ -967,6 +968,7 @@ test('aws-waf (header)', t => {
   const result = isAntibot({ headers })
   t.is(result.detected, true)
   t.is(result.provider, 'aws-waf')
+  t.is(result.technique, 'javascript')
 })
 
 test('aws-waf (html aws-waf)', t => {

--- a/test/interface.js
+++ b/test/interface.js
@@ -11,7 +11,7 @@ const headers = { 'user-agent': 'curl/7.81.0' }
 test('from fetch', async t => {
   const response = await fetch(url, { headers })
   const html = await response.text()
-  const { detected, provider, detection } = isAntibot({
+  const { detected, provider, detection, technique } = isAntibot({
     headers: response.headers,
     statusCode: response.status,
     html,
@@ -22,14 +22,16 @@ test('from fetch', async t => {
   t.true(
     ['headers', 'cookies', 'html', 'url', 'statusCode'].includes(detection)
   )
+  t.true(['javascript', 'captcha', 'waf', 'cookie'].includes(technique))
 })
 
 test('from got', async t => {
   const response = await got(url, { headers }).catch(error => error.response)
-  const { detected, provider, detection } = isAntibot(response)
+  const { detected, provider, detection, technique } = isAntibot(response)
   t.is(detected, true)
   t.is(provider, 'linkedin')
   t.true(
     ['headers', 'cookies', 'html', 'url', 'statusCode'].includes(detection)
   )
+  t.true(['javascript', 'captcha', 'waf', 'cookie'].includes(technique))
 })

--- a/test/interface.js
+++ b/test/interface.js
@@ -22,7 +22,7 @@ test('from fetch', async t => {
   t.true(
     ['headers', 'cookies', 'html', 'url', 'statusCode'].includes(detection)
   )
-  t.true(['javascript', 'captcha', 'waf', 'cookie'].includes(technique))
+  t.is(technique, 'waf')
 })
 
 test('from got', async t => {
@@ -33,5 +33,5 @@ test('from got', async t => {
   t.true(
     ['headers', 'cookies', 'html', 'url', 'statusCode'].includes(detection)
   )
-  t.true(['javascript', 'captcha', 'waf', 'cookie'].includes(technique))
+  t.is(technique, 'waf')
 })

--- a/test/providers.js
+++ b/test/providers.js
@@ -12,6 +12,10 @@ test('true', async t => {
     const result = isAntibot(fixture)
     t.is(result.detected, true, `Failed ${name}`)
     t.truthy(result.provider, `Failed ${name}`)
+    t.true(
+      ['javascript', 'captcha', 'waf', 'cookie'].includes(result.technique),
+      `Failed ${name} technique`
+    )
   }
 })
 

--- a/test/rule-compiler.js
+++ b/test/rule-compiler.js
@@ -127,6 +127,7 @@ test('provider and detection order determines precedence', t => {
 
   t.is(result.provider, 'first-provider')
   t.is(result.detection, 'url')
+  t.is(result.technique, null)
 })
 
 test('regex flags honors explicit empty string and defaults to i when omitted', t => {

--- a/test/schema.js
+++ b/test/schema.js
@@ -133,7 +133,13 @@ const validateProvider = provider =>
   validate(provider, schema.$defs.provider, schema)
 
 test('provider requires label and category', t => {
-  const detections = [{ type: 'html', rules: [{ contains: 'challenge' }] }]
+  const detections = [
+    {
+      type: 'html',
+      technique: 'javascript',
+      rules: [{ contains: 'challenge' }]
+    }
+  ]
 
   t.deepEqual(validateProvider({ name: 'acme', detections }), [
     '$ is missing required property "label"',
@@ -168,5 +174,31 @@ test('provider requires label and category', t => {
       detections
     }),
     []
+  )
+})
+
+test('detection requires technique', t => {
+  t.deepEqual(
+    validateProvider({
+      name: 'acme',
+      label: 'Acme',
+      category: 'antibot',
+      detections: [{ type: 'html', rules: [{ contains: 'challenge' }] }]
+    }),
+    ['$.detections[0] is missing required property "technique"']
+  )
+
+  t.deepEqual(
+    validateProvider({
+      name: 'acme',
+      label: 'Acme',
+      category: 'antibot',
+      detections: [
+        { type: 'html', technique: 'browser', rules: [{ contains: 'x' }] }
+      ]
+    }),
+    [
+      '$.detections[0].technique should be one of: javascript, captcha, waf, cookie'
+    ]
   )
 })

--- a/test/schema.js
+++ b/test/schema.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const fs = require('fs')
+const path = require('path')
 const test = require('ava')
 
 const schema = require('../src/schema.json')
@@ -123,6 +125,17 @@ const validate = (value, definition, root, path = '$') => {
 
   return errors
 }
+
+test('typescript ProviderName matches the catalog', t => {
+  const dts = fs.readFileSync(path.join(__dirname, '../src/index.d.ts'), 'utf8')
+  const block = dts.match(/type ProviderName =([\s\S]*?)interface Input/)
+  t.truthy(block, 'ProviderName union is present')
+  const names = [...block[1].matchAll(/'([^']+)'/g)].map(([, name]) => name)
+  t.deepEqual(
+    names,
+    providers.providers.map(({ name }) => name)
+  )
+})
 
 test('providers json conforms to providers schema', t => {
   const errors = validate(providers, schema, schema)


### PR DESCRIPTION
## Summary
- Each detection now declares a `technique` (`javascript`, `captcha`, `waf`, `cookie`).
- The result is `{ detected, provider, detection, technique }` so callers can choose render vs IP retry without a domain list.
- Cloudflare JS interstitials (`cf-mitigated`, `_cf_chl_opt`) are `javascript`; `cf_clearance` is `cookie`.

## Test plan
- [x] `pnpm test`
- [ ] Microlink `getDiscoveryGroups(domain, technique)` uses render lanes for `javascript`/`captcha` after this ships


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Detection results now include a `technique` field describing how a provider was identified.
  - Supported techniques include JavaScript, CAPTCHA, WAF, and cookie detection.
  - Overlapping or inconclusive detections report no technique.

- **Documentation**
  - Quick Start, reference documentation, and examples now show the technique alongside the provider and detection signal.
  - Blocked-request logs include the detected technique to support clearer retry and troubleshooting decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->