### PR TITLE
feat: detect CloudFront error pages as waf

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -141,6 +141,7 @@ Each provider has unique fingerprints across one or more of these signals. The l
       <tr><td>Cheq</td><td>Antibot</td><td>2</td><td><span class="provider-chip">HTML</span><span class="provider-chip">URL</span></td></tr>
       <tr><td>Cloudflare</td><td>Antibot</td><td>3</td><td><span class="provider-chip">Headers</span><span class="provider-chip">Cookies</span><span class="provider-chip">HTML</span></td></tr>
       <tr><td>Cloudflare Turnstile</td><td>CAPTCHA</td><td>2</td><td><span class="provider-chip">HTML</span><span class="provider-chip">URL</span></td></tr>
+      <tr><td>CloudFront</td><td>Antibot</td><td>2</td><td><span class="provider-chip">Headers</span><span class="provider-chip">HTML</span></td></tr>
       <tr><td>DataDome</td><td>Antibot</td><td>2</td><td><span class="provider-chip">Headers</span><span class="provider-chip">Cookies</span></td></tr>
       <tr><td>Douban</td><td>Platform-specific</td><td>1</td><td><span class="provider-chip">Status Code</span></td></tr>
       <tr><td>Dribbble</td><td>Platform-specific</td><td>1</td><td><span class="provider-chip">Status Code</span></td></tr>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,7 +15,7 @@ Detected antibot systems:
 
 - Cloudflare, Vercel, Akamai, DataDome, PerimeterX, Shape Security, Kasada
 - Imperva / Incapsula, Reblaze, Cheq, Sucuri, ThreatMetrix, Meetrics
-- Ocule, Anubis, FullStory Challenge, AWS WAF
+- Ocule, CloudFront, Anubis, FullStory Challenge, AWS WAF
 
 Detected CAPTCHA providers:
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,7 +15,7 @@ Detected antibot systems:
 
 - Cloudflare, Vercel, Akamai, DataDome, PerimeterX, Shape Security, Kasada
 - Imperva / Incapsula, Reblaze, Cheq, Sucuri, ThreatMetrix, Meetrics
-- Ocule, CloudFront, Anubis, FullStory Challenge, AWS WAF
+- Ocule, Anubis, FullStory Challenge, AWS WAF, CloudFront
 
 Detected CAPTCHA providers:
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,6 +36,7 @@ declare namespace isAntibot {
     | 'instagram'
     | 'youtube'
     | 'amazon'
+    | 'cloudfront'
     | 'anubis'
     | 'fullstory-challenge'
     | 'aws-waf'

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,13 +36,13 @@ declare namespace isAntibot {
     | 'instagram'
     | 'youtube'
     | 'amazon'
-    | 'cloudfront'
     | 'anubis'
     | 'fullstory-challenge'
     | 'aws-waf'
     | 'weibo'
     | 'dribbble'
     | 'douban'
+    | 'cloudfront'
 
   interface Input {
     headers?: HeadersLike

--- a/src/providers.json
+++ b/src/providers.json
@@ -872,6 +872,33 @@
       ]
     },
     {
+      "name": "cloudfront",
+      "label": "CloudFront",
+      "category": "antibot",
+      "detections": [
+        {
+          "type": "headers",
+          "technique": "waf",
+          "rules": [
+            {
+              "header": "x-cache",
+              "startsWith": "Error from cloudfront"
+            }
+          ]
+        },
+        {
+          "type": "html",
+          "technique": "waf",
+          "statusCodes": [403, 502, 503, 504],
+          "rules": [
+            {
+              "contains": "The request could not be satisfied"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "anubis",
       "label": "Anubis",
       "category": "antibot",

--- a/src/providers.json
+++ b/src/providers.json
@@ -872,33 +872,6 @@
       ]
     },
     {
-      "name": "cloudfront",
-      "label": "CloudFront",
-      "category": "antibot",
-      "detections": [
-        {
-          "type": "headers",
-          "technique": "waf",
-          "rules": [
-            {
-              "header": "x-cache",
-              "startsWith": "Error from cloudfront"
-            }
-          ]
-        },
-        {
-          "type": "html",
-          "technique": "waf",
-          "statusCodes": [403, 502, 503, 504],
-          "rules": [
-            {
-              "contains": "The request could not be satisfied"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "name": "anubis",
       "label": "Anubis",
       "category": "antibot",
@@ -1034,6 +1007,34 @@
           "rules": [
             {
               "status": 418
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "cloudfront",
+      "label": "CloudFront",
+      "category": "antibot",
+      "detections": [
+        {
+          "type": "headers",
+          "technique": "waf",
+          "statusCodes": [403, 502, 503, 504],
+          "rules": [
+            {
+              "header": "x-cache",
+              "startsWith": "Error from cloudfront"
+            }
+          ]
+        },
+        {
+          "type": "html",
+          "technique": "waf",
+          "statusCodes": [403, 502, 503, 504],
+          "rules": [
+            {
+              "contains": "The request could not be satisfied"
             }
           ]
         }

--- a/test/index.js
+++ b/test/index.js
@@ -893,21 +893,23 @@ test('amazon (x-cache Error from cloudfront + amazon URL + status 500)', t => {
   t.is(result.detection, 'headers')
 })
 
-test('amazon (no match without status 500)', t => {
+test('amazon (status 200 cloudfront error is not amazon)', t => {
   const result = isAntibot({
     url: 'https://www.amazon.com/dp/B000000000',
     headers: { 'x-cache': 'Error from cloudfront' },
     statusCode: 200
   })
-  t.is(result.detected, false)
+  t.not(result.provider, 'amazon')
+  t.is(result.provider, 'cloudfront')
 })
 
-test('amazon (no match when statusCode omitted)', t => {
+test('amazon (omitted status cloudfront error is not amazon)', t => {
   const result = isAntibot({
     url: 'https://www.amazon.com/dp/B000000000',
     headers: { 'x-cache': 'Error from cloudfront' }
   })
-  t.is(result.detected, false)
+  t.not(result.provider, 'amazon')
+  t.is(result.provider, 'cloudfront')
 })
 
 test('amazon (captcha page with csm-captcha-instrumentation)', t => {
@@ -930,10 +932,51 @@ test('amazon (csm-captcha-instrumentation on non-amazon URL should not match)', 
   t.is(result.detected, false)
 })
 
-test('amazon (no false positive: CloudFront error off amazon)', t => {
+test('amazon (cloudfront error off amazon is not amazon)', t => {
   const result = isAntibot({
     url: 'https://example.com/',
     headers: { 'x-cache': 'Error from cloudfront' }
+  })
+  t.not(result.provider, 'amazon')
+})
+
+test('cloudfront (x-cache Error from cloudfront)', t => {
+  const result = isAntibot({
+    url: 'https://www.un.org/en/about-us',
+    headers: { 'x-cache': 'Error from cloudfront' },
+    statusCode: 403
+  })
+  t.is(result.detected, true)
+  t.is(result.provider, 'cloudfront')
+  t.is(result.technique, 'waf')
+})
+
+test('cloudfront (html error page on 403)', t => {
+  const result = isAntibot({
+    url: 'https://www.un.org/en/about-us',
+    html: '<title>ERROR: The request could not be satisfied</title>',
+    statusCode: 403
+  })
+  t.is(result.detected, true)
+  t.is(result.provider, 'cloudfront')
+  t.is(result.technique, 'waf')
+})
+
+test('cloudfront (no false positive: Miss from cloudfront on 200)', t => {
+  const result = isAntibot({
+    url: 'https://www.un.org/en/about-us',
+    headers: { 'x-cache': 'Miss from cloudfront' },
+    html: '<title>About Us | United Nations</title>',
+    statusCode: 200
+  })
+  t.is(result.detected, false)
+})
+
+test('cloudfront (no false positive: error copy on a 200 page)', t => {
+  const result = isAntibot({
+    url: 'https://example.com/cloudfront-errors',
+    html: '<p>The request could not be satisfied. CloudFront returns this when the request is blocked.</p>',
+    statusCode: 200
   })
   t.is(result.detected, false)
 })

--- a/test/index.js
+++ b/test/index.js
@@ -775,6 +775,16 @@ test('dribbble (403 forbidden to bots)', t => {
   t.is(result.detection, 'statusCode')
 })
 
+test('dribbble (403 with CloudFront error header stays dribbble)', t => {
+  const result = isAntibot({
+    statusCode: 403,
+    url: 'https://dribbble.com/omidnikrah',
+    headers: { 'x-cache': 'Error from cloudfront' }
+  })
+  t.is(result.detected, true)
+  t.is(result.provider, 'dribbble')
+})
+
 test('douban (image cdn 418 without referer)', t => {
   const result = isAntibot({
     statusCode: 418,
@@ -893,23 +903,21 @@ test('amazon (x-cache Error from cloudfront + amazon URL + status 500)', t => {
   t.is(result.detection, 'headers')
 })
 
-test('amazon (status 200 cloudfront error is not amazon)', t => {
+test('amazon (no match without status 500)', t => {
   const result = isAntibot({
     url: 'https://www.amazon.com/dp/B000000000',
     headers: { 'x-cache': 'Error from cloudfront' },
     statusCode: 200
   })
-  t.not(result.provider, 'amazon')
-  t.is(result.provider, 'cloudfront')
+  t.is(result.detected, false)
 })
 
-test('amazon (omitted status cloudfront error is not amazon)', t => {
+test('amazon (no match when statusCode omitted)', t => {
   const result = isAntibot({
     url: 'https://www.amazon.com/dp/B000000000',
     headers: { 'x-cache': 'Error from cloudfront' }
   })
-  t.not(result.provider, 'amazon')
-  t.is(result.provider, 'cloudfront')
+  t.is(result.detected, false)
 })
 
 test('amazon (captcha page with csm-captcha-instrumentation)', t => {
@@ -935,9 +943,11 @@ test('amazon (csm-captcha-instrumentation on non-amazon URL should not match)', 
 test('amazon (cloudfront error off amazon is not amazon)', t => {
   const result = isAntibot({
     url: 'https://example.com/',
-    headers: { 'x-cache': 'Error from cloudfront' }
+    headers: { 'x-cache': 'Error from cloudfront' },
+    statusCode: 403
   })
   t.not(result.provider, 'amazon')
+  t.is(result.provider, 'cloudfront')
 })
 
 test('cloudfront (x-cache Error from cloudfront)', t => {
@@ -960,6 +970,15 @@ test('cloudfront (html error page on 403)', t => {
   t.is(result.detected, true)
   t.is(result.provider, 'cloudfront')
   t.is(result.technique, 'waf')
+})
+
+test('cloudfront (no false positive: Error from cloudfront on 200)', t => {
+  const result = isAntibot({
+    url: 'https://www.un.org/en/about-us',
+    headers: { 'x-cache': 'Error from cloudfront' },
+    statusCode: 200
+  })
+  t.is(result.detected, false)
 })
 
 test('cloudfront (no false positive: Miss from cloudfront on 200)', t => {


### PR DESCRIPTION
## Summary
- `www.un.org` 403s with `x-cache: Error from cloudfront` and title `ERROR: The request could not be satisfied` were a detector **miss** (`no challenge detected`, `provider=null`), so scrape.do never ran.
- Fixtures: curl 403 is the error page; `html-get` fetch/prerender and scrape.do **datacenter** return `About Us | United Nations` with `x-cache: Miss from cloudfront`.
- New `cloudfront` provider: header `Error from cloudfront` (waf), plus the error-page copy on 403/502/503/504. Amazon's 500+domain rule still wins first.

## Test plan
- [x] `pnpm test`
- [ ] After publish + API bump: `force=true` on `https://www.un.org/en/about-us` (this payload was an API cache HIT)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection support for CloudFront as an antibot provider.
  * CloudFront can now be identified through response headers and blocked-request HTML signals across common error statuses.
  * Added `cloudfront` as a recognized provider name.

* **Tests**
  * Expanded coverage for CloudFront error responses, WAF blocks, HTML error pages, and unrelated or successful responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->