### PR TITLE
ci: use the same npmrc auth as metascraper

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
           git config --global user.name ${{ secrets.GIT_USERNAME }}
           git pull origin master
           VERSION_BEFORE=$(node -p "require('./package.json').version")
+          pnpm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
           pnpm run release
           VERSION_AFTER=$(node -p "require('./package.json').version")
           if [ "$VERSION_BEFORE" != "$VERSION_AFTER" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ npm-debug.log
 .node_history
 yarn.lock
 package-lock.json
+pnpm-lock.yaml
 
 ############################
 # tmp, editor & OS files

--- a/.npmrc
+++ b/.npmrc
@@ -10,3 +10,4 @@ save=false
 shamefully-hoist=true
 strict-peer-dependencies=false
 unsafe-perm=true
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
## Summary
- Same release auth recipe as [metascraper](https://github.com/microlinkhq/metascraper), [keyvhq](https://github.com/microlinkhq/keyvhq), and [browserless #897](https://github.com/microlinkhq/browserless/pull/897):
  - `.npmrc` keeps `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` so npm/`ci-publish` can expand it
  - release step runs `pnpm config set` because pnpm 11 ignores the project `.npmrc` token
  - ignore `pnpm-lock.yaml` so a generated lockfile cannot dirty the tree mid-publish
- Does **not** write the token into the project `.npmrc` at CI time.

## Note
The latest [master release](https://github.com/microlinkhq/is-antibot/actions/runs/32758253303) is failing earlier than auth: `conventional-changelog-conventionalcommits` v10 needs writer@9, and `conventional-changelog-cli@latest` still loads an older writer. This PR does not change that. A `ci:` merge also skips the release job by design.

## Test plan
- [ ] Confirm `.npmrc` still has no expanded token after a local/CI install
- [ ] After the next non-`ci:`/`docs:` master commit, `npm publish` sees the token
- [ ] `pnpm-lock.yaml` is not committed if install writes one


Made with [Cursor](https://cursor.com)