### PR TITLE
fix: ignore captcha widgets on served pages

### DIFF
--- a/providers/hcaptcha/failed.json
+++ b/providers/hcaptcha/failed.json
@@ -1,0 +1,64 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "microlink-api",
+      "version": "1.0.0"
+    },
+    "pages": [
+      {
+        "id": "page_1",
+        "title": "Tennis - Gamma Sports",
+        "startedDateTime": "2026-08-25T05:00:00.000Z",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": 100
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2026-08-25T05:00:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
+        "connection": "443",
+        "request": {
+          "method": "GET",
+          "url": "https://www.gammasports.com/collections/tennis",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "host",
+              "value": "www.gammasports.com"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 189,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html><head><title>Tennis - Gamma Sports</title></head><body><script src=\"https://hcaptcha.com/1/api.js\"></script><div class=\"h-captcha\" data-sitekey=\"k\"></div></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 189
+        }
+      }
+    ]
+  }
+}

--- a/providers/hcaptcha/success.json
+++ b/providers/hcaptcha/success.json
@@ -1,0 +1,64 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "microlink-api",
+      "version": "1.0.0"
+    },
+    "pages": [
+      {
+        "id": "page_1",
+        "title": "Tennis - Gamma Sports",
+        "startedDateTime": "2026-08-25T05:00:00.000Z",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": 100
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2026-08-25T05:00:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
+        "connection": "443",
+        "request": {
+          "method": "GET",
+          "url": "https://www.gammasports.com/collections/tennis",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "host",
+              "value": "www.gammasports.com"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 283,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html><head><title>Tennis - Gamma Sports</title></head><body><script id=\"captcha-bootstrap\">const d=['recaptcha-v3-token','g-recaptcha-response','h-captcha-response']</script><main><h1>Tennis</h1><p>Pickleball paddles and tennis gear in stock.</p></main></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 283
+        }
+      }
+    ]
+  }
+}

--- a/providers/recaptcha/success.json
+++ b/providers/recaptcha/success.json
@@ -1,0 +1,69 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "microlink-api",
+      "version": "1.0.0"
+    },
+    "pages": [
+      {
+        "id": "page_1",
+        "title": "온라인 학교폭력의 실태",
+        "startedDateTime": "2026-08-25T05:00:00.000Z",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": 100
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2026-08-25T05:00:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
+        "connection": "443",
+        "request": {
+          "method": "GET",
+          "url": "http://www.jeonmin.co.kr/news/articleView.html?idxno=353270",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "host",
+              "value": "www.jeonmin.co.kr"
+            }
+          ],
+          "queryString": [
+            {
+              "name": "idxno",
+              "value": "353270"
+            }
+          ],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 298,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html><head><title>온라인 학교폭력의 실태</title></head><body><article><h1>사이버 불링</h1><p>학교폭력의 실태를 다룬 기사입니다.</p></article><input id=\"g-recaptcha-response\" name=\"g-recaptcha-response\" type=\"hidden\" value=\"\" /><script>grecaptcha.render('captcha_container', {sitekey: 'k'})</script></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 298
+        }
+      }
+    ]
+  }
+}

--- a/src/providers.json
+++ b/src/providers.json
@@ -472,7 +472,7 @@
               "contains": "recaptcha.net"
             },
             {
-              "regex": "(?:^|//)(?:www\\.)?google\\.com/recaptcha/(?:api|enterprise)",
+              "regex": "^https?://(?:www\\.)?google\\.com/recaptcha/(?:api|enterprise)",
               "flags": "i"
             }
           ]

--- a/src/providers.json
+++ b/src/providers.json
@@ -472,7 +472,7 @@
               "contains": "recaptcha.net"
             },
             {
-              "regex": "google\\.com\\/recaptcha",
+              "regex": "(?:^|//)(?:www\\.)?google\\.com/recaptcha/(?:api|enterprise)",
               "flags": "i"
             }
           ]
@@ -482,7 +482,7 @@
           "technique": "captcha",
           "rules": [
             {
-              "regex": "^(?=[\\s\\S]*g-recaptcha)(?=[\\s\\S]*grecaptcha\\s*\\.\\s*render)",
+              "regex": "^(?=[\\s\\S]*captcha-form)(?=[\\s\\S]*g-recaptcha)",
               "flags": "i"
             }
           ]
@@ -549,7 +549,7 @@
               "contains": "hcaptcha.com"
             },
             {
-              "contains": "h-captcha"
+              "regex": "h-captcha(?!-response)"
             }
           ]
         }

--- a/test/index.js
+++ b/test/index.js
@@ -514,9 +514,25 @@ test('recaptcha (no false positive: g-recaptcha widget on a 200 content page)', 
   t.is(result.provider, null)
 })
 
-test('recaptcha (html active grecaptcha on a 200 page is still a block)', t => {
+test('recaptcha (comment-form grecaptcha.render on a 200 page is not a block)', t => {
   const html =
-    '<div class="g-recaptcha"></div><script>grecaptcha.render("x")</script>'
+    '<article>real article</article><input name="g-recaptcha-response"><script>grecaptcha.render("x")</script>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+})
+
+test('recaptcha (docs URL is not a captcha endpoint)', t => {
+  const result = isAntibot({
+    url: 'https://docs.cloud.google.com/recaptcha/docs/create-key-website',
+    html: '<html><title>Create a key</title></html>',
+    statusCode: 200
+  })
+  t.is(result.detected, false)
+})
+
+test('recaptcha (Google unusual-traffic interstitial on a 200)', t => {
+  const html =
+    '<form id="captcha-form"><div class="g-recaptcha" data-sitekey="k"></div></form>'
   const result = isAntibot({ html, statusCode: 200 })
   t.is(result.detected, true)
   t.is(result.provider, 'recaptcha')
@@ -547,6 +563,13 @@ test('hcaptcha (html h-captcha)', t => {
   const result = isAntibot({ html })
   t.is(result.detected, true)
   t.is(result.provider, 'hcaptcha')
+})
+
+test('hcaptcha (no false positive for Shopify h-captcha-response field)', t => {
+  const html =
+    "<script>const d=['recaptcha-v3-token','g-recaptcha-response','h-captcha-response']</script><article>Tennis paddles</article>"
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
 })
 
 test('funcaptcha (url with arkoselabs)', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -530,6 +530,14 @@ test('recaptcha (docs URL is not a captcha endpoint)', t => {
   t.is(result.detected, false)
 })
 
+test('recaptcha (nested google.com/recaptcha in another host path is not a block)', t => {
+  const result = isAntibot({
+    url: 'https://example.test/redirect/https://www.google.com/recaptcha/enterprise.js',
+    statusCode: 200
+  })
+  t.is(result.detected, false)
+})
+
 test('recaptcha (Google unusual-traffic interstitial on a 200)', t => {
   const html =
     '<form id="captcha-form"><div class="g-recaptcha" data-sitekey="k"></div></form>'


### PR DESCRIPTION
## Summary
- Shopify storefronts ship `h-captcha-response` in the captcha-bootstrap script on every 200. That substring was enough to flag the page as hCaptcha and send it up the render ladder (30 units, 0 resolves).
- News comment forms call `grecaptcha.render` on a fully served article. Same ladder. Docs URLs containing `/recaptcha/` were also treated as captcha endpoints.
- Real challenges still match: `hcaptcha.com` / `class="h-captcha"`, Google's `captcha-form` interstitial on 200, and `g-recaptcha` on 403/429/503.

Replay against last-15m captures: **30 units → 0** (Shopify), **35 → 0** (jeonmin), YouTube 429 interstitial still detected.

## Test plan
- [x] `ava test/index.js test/providers.js` (155 passed)
- [ ] Confirm production still flags a real Google unusual-traffic page after the npm release + API dep bump


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reCAPTCHA detection to better identify genuine challenge pages and endpoints.
  - Reduced false positives for ordinary pages containing reCAPTCHA-related scripts or response fields.
  - Improved hCaptcha detection by distinguishing the actual widget from response fields.
  - Added support for accurately recognizing hCaptcha and reCAPTCHA challenges across additional page formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->