### PR TITLE
ci: write the npm token at release time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,6 @@ jobs:
           git config --global user.name ${{ secrets.GIT_USERNAME }}
           git pull origin master
           VERSION_BEFORE=$(node -p "require('./package.json').version")
-          pnpm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
           npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
           pnpm run release
           VERSION_AFTER=$(node -p "require('./package.json').version")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,7 @@ jobs:
           git pull origin master
           VERSION_BEFORE=$(node -p "require('./package.json').version")
           pnpm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
+          npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
           pnpm run release
           VERSION_AFTER=$(node -p "require('./package.json').version")
           if [ "$VERSION_BEFORE" != "$VERSION_AFTER" ]; then

--- a/.npmrc
+++ b/.npmrc
@@ -10,4 +10,3 @@ save=false
 shamefully-hoist=true
 strict-peer-dependencies=false
 unsafe-perm=true
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
## Summary
- Remove `${NPM_TOKEN}` from the committed `.npmrc` so pnpm 11 stops warning on every install.
- At release, write the token to **both** pnpm and npm user config (`pnpm config set` + `npm config set`). `ci-publish` / `npm publish` need the npm store. Neither write touches the repo.

## Test plan
- [ ] CI logs have no "Ignored project-level auth setting" warning
- [ ] Next real release can `npm publish`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-time credential setup only; no app or security logic changes, but a failed `npm config set` could block publishing until fixed.
> 
> **Overview**
> Stops committing **npm registry auth** in `.npmrc` so **pnpm 11** no longer warns about ignored project-level `_authToken` on every install.
> 
> The **release** job now writes the token only at publish time via `npm config set "//registry.npmjs.org/:_authToken"`, replacing the previous `pnpm config set` in CI. That matches **`postrelease`**, which runs `ci-publish` / `npm publish` and reads **npm** user config, not the repo `.npmrc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a69cab4b1c2ae0ddb00e10ca299a75b454e6761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->