### PR TITLE
fix: ignore Turnstile widgets on served pages

### DIFF
--- a/providers/cloudflare-turnstile/failed.json
+++ b/providers/cloudflare-turnstile/failed.json
@@ -1,0 +1,68 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "microlink-api",
+      "version": "1.0.0"
+    },
+    "pages": [
+      {
+        "id": "page_1",
+        "title": "Just a moment...",
+        "startedDateTime": "2026-08-25T08:00:00.000Z",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": 100
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2026-08-25T08:00:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
+        "connection": "443",
+        "request": {
+          "method": "GET",
+          "url": "https://www.nknews.org/2026/06/tuberculosis-cases-trigger-mandatory-treatment-of-north-korean-workers-in-russia/",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "host",
+              "value": "www.nknews.org"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 217,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html><head><title>Just a moment...</title></head><body><div class=\"cf-turnstile\" data-sitekey=\"k\"></div><script src=\"https://challenges.cloudflare.com/turnstile/v0/api.js\" defer></script></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 217
+        }
+      }
+    ]
+  }
+}

--- a/providers/cloudflare-turnstile/success.json
+++ b/providers/cloudflare-turnstile/success.json
@@ -1,0 +1,68 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "microlink-api",
+      "version": "1.0.0"
+    },
+    "pages": [
+      {
+        "id": "page_1",
+        "title": "Tuberculosis cases trigger mandatory treatment of North Korean workers in Russia",
+        "startedDateTime": "2026-08-25T08:00:00.000Z",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": 100
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2026-08-25T08:00:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
+        "connection": "443",
+        "request": {
+          "method": "GET",
+          "url": "https://www.nknews.org/2026/06/tuberculosis-cases-trigger-mandatory-treatment-of-north-korean-workers-in-russia/",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "host",
+              "value": "www.nknews.org"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 349,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html><head><title>Tuberculosis cases trigger mandatory treatment of North Korean workers in Russia</title></head><body><article><h1>Tuberculosis cases</h1><p>North Korean workers in Russia must undergo mandatory treatment.</p></article><script src=\"https://challenges.cloudflare.com/turnstile/v0/api.js\" defer></script></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 349
+        }
+      }
+    ]
+  }
+}

--- a/src/providers.json
+++ b/src/providers.json
@@ -633,6 +633,21 @@
           "technique": "captcha",
           "rules": [
             {
+              "regex": "^(?=[\\s\\S]*cf-turnstile)(?=[\\s\\S]*(?:Just a moment|Attention Required|Verify you are (?:a )?human))",
+              "flags": "i"
+            }
+          ]
+        },
+        {
+          "type": "html",
+          "technique": "captcha",
+          "statusCodes": [
+            403,
+            429,
+            503
+          ],
+          "rules": [
+            {
               "contains": "cf-turnstile"
             },
             {

--- a/test/index.js
+++ b/test/index.js
@@ -655,17 +655,34 @@ test('cloudflare-turnstile (url)', t => {
   t.is(result.provider, 'cloudflare-turnstile')
 })
 
-test('cloudflare-turnstile (html cf-turnstile)', t => {
+test('cloudflare-turnstile (html cf-turnstile on a blocking status)', t => {
   const html = '<div class="cf-turnstile"></div>'
-  const result = isAntibot({ html })
+  for (const statusCode of [403, 429, 503]) {
+    const result = isAntibot({ html, statusCode })
+    t.is(result.detected, true, `should detect for status ${statusCode}`)
+    t.is(result.provider, 'cloudflare-turnstile')
+  }
+})
+
+test('cloudflare-turnstile (widget on a 200 content page is not a block)', t => {
+  const html =
+    '<article>real article</article><script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script><div class="cf-turnstile"></div>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+})
+
+test('cloudflare-turnstile (html turnstile API on a blocking status)', t => {
+  const html =
+    '<script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>'
+  const result = isAntibot({ html, statusCode: 403 })
   t.is(result.detected, true)
   t.is(result.provider, 'cloudflare-turnstile')
 })
 
-test('cloudflare-turnstile (html turnstile API)', t => {
+test('cloudflare-turnstile (Just a moment interstitial on a 200)', t => {
   const html =
-    '<script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>'
-  const result = isAntibot({ html })
+    '<title>Just a moment...</title><div class="cf-turnstile" data-sitekey="k"></div>'
+  const result = isAntibot({ html, statusCode: 200 })
   t.is(result.detected, true)
   t.is(result.provider, 'cloudflare-turnstile')
 })


### PR DESCRIPTION
## Summary
- Content pages that embed the Turnstile widget script on a 200 were flagged as a challenge.
- Gate `cf-turnstile` / the API script on 403/429/503. Keep a 200 interstitial (`Just a moment` + `cf-turnstile`). Real Cloudflare JS challenges still match `_cf_chl_opt` first.
- Captured articles (e.g. news/blog posts with a comment or paywall widget) no longer detect, and do not fall through to another provider.

## Test plan
- [x] `ava test/index.js test/providers.js` (158 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloudflare Turnstile detection by recognizing common challenge-page messaging, including “Just a moment” and “Verify you are human.”
  * Reduced false positives by considering HTTP status codes and allowing legitimate 200-status content pages with Turnstile elements.
* **Tests**
  * Added success and failure scenarios covering blocked responses, challenge interstitials, and valid content pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->