### PR TITLE
fix: ignore AWS WAF and captcha widgets on served pages

### DIFF
--- a/providers/aws-waf/failed.json
+++ b/providers/aws-waf/failed.json
@@ -60,7 +60,7 @@
           "content": {
             "size": 277,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>Genesis -part 9</title></head><body><article><h1>Genesis -part 9</h1><p>Discover Your Library</p></article><script>window.WEB_ACL_INTEGRATION_URL=\"https://a40627b4876a.edge.sdk.awswaf.com/a40627b4876a/b00be2a099fd\"</script></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>Genesis -part 9</title><script src=\"https://a40627b4876a.edge.sdk.awswaf.com/a40627b4876a/challenge.js\" defer></script></head><body><article><h1>Genesis -part 9</h1><p>Discover Your Library</p></article></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,

--- a/providers/aws-waf/failed.json
+++ b/providers/aws-waf/failed.json
@@ -8,7 +8,7 @@
     "pages": [
       {
         "id": "page_1",
-        "title": "Les Personas Synthétiques sont-ils la Nouvelle Norme de la Recherche Utilisateur ?",
+        "title": "Genesis -part 9",
         "startedDateTime": "2026-08-25T13:00:00.000Z",
         "pageTimings": {
           "onContentLoad": -1,
@@ -25,12 +25,12 @@
         "connection": "443",
         "request": {
           "method": "GET",
-          "url": "https://www.delve.ai/fr/blog/personas-synthetiques",
+          "url": "https://open.spreaker.com/A4NZ/r8gof0tb",
           "httpVersion": "http/1.1",
           "headers": [
             {
               "name": "host",
-              "value": "www.delve.ai"
+              "value": "open.spreaker.com"
             }
           ],
           "queryString": [],
@@ -46,17 +46,25 @@
             {
               "name": "content-type",
               "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "x-amzn-requestid",
+              "value": "ee270925-a72c-4312-a2c7-c680bc157787"
+            },
+            {
+              "name": "x-amzn-waf-action",
+              "value": "challenge"
             }
           ],
           "cookies": [],
           "content": {
-            "size": 398,
+            "size": 277,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>Les Personas Synthétiques sont-ils la Nouvelle Norme de la Recherche Utilisateur ?</title><style>.c-search-captcha{display:flex}</style></head><body><article><h1>Personas</h1><p>Delve AI has been featured in Gartner's Hype Cycle.</p></article><script src=\"https://hcaptcha.com/1/api.js\"></script></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>Genesis -part 9</title></head><body><article><h1>Genesis -part 9</h1><p>Discover Your Library</p></article><script>window.WEB_ACL_INTEGRATION_URL=\"https://a40627b4876a.edge.sdk.awswaf.com/a40627b4876a/b00be2a099fd\"</script></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 398
+          "bodySize": 277
         }
       }
     ]

--- a/providers/aws-waf/success.json
+++ b/providers/aws-waf/success.json
@@ -56,7 +56,7 @@
           "content": {
             "size": 277,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>Genesis -part 9</title></head><body><article><h1>Genesis -part 9</h1><p>Discover Your Library</p></article><script>window.WEB_ACL_INTEGRATION_URL=\"https://a40627b4876a.edge.sdk.awswaf.com/a40627b4876a/b00be2a099fd\"</script></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>Genesis -part 9</title><script src=\"https://a40627b4876a.edge.sdk.awswaf.com/a40627b4876a/challenge.js\" defer></script></head><body><article><h1>Genesis -part 9</h1><p>Discover Your Library</p></article></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,

--- a/providers/aws-waf/success.json
+++ b/providers/aws-waf/success.json
@@ -8,7 +8,7 @@
     "pages": [
       {
         "id": "page_1",
-        "title": "Les Personas Synthétiques sont-ils la Nouvelle Norme de la Recherche Utilisateur ?",
+        "title": "Genesis -part 9",
         "startedDateTime": "2026-08-25T13:00:00.000Z",
         "pageTimings": {
           "onContentLoad": -1,
@@ -25,12 +25,12 @@
         "connection": "443",
         "request": {
           "method": "GET",
-          "url": "https://www.delve.ai/fr/blog/personas-synthetiques",
+          "url": "https://open.spreaker.com/A4NZ/r8gof0tb",
           "httpVersion": "http/1.1",
           "headers": [
             {
               "name": "host",
-              "value": "www.delve.ai"
+              "value": "open.spreaker.com"
             }
           ],
           "queryString": [],
@@ -46,17 +46,21 @@
             {
               "name": "content-type",
               "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "x-amzn-requestid",
+              "value": "ee270925-a72c-4312-a2c7-c680bc157787"
             }
           ],
           "cookies": [],
           "content": {
-            "size": 398,
+            "size": 277,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>Les Personas Synthétiques sont-ils la Nouvelle Norme de la Recherche Utilisateur ?</title><style>.c-search-captcha{display:flex}</style></head><body><article><h1>Personas</h1><p>Delve AI has been featured in Gartner's Hype Cycle.</p></article><script src=\"https://hcaptcha.com/1/api.js\"></script></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>Genesis -part 9</title></head><body><article><h1>Genesis -part 9</h1><p>Discover Your Library</p></article><script>window.WEB_ACL_INTEGRATION_URL=\"https://a40627b4876a.edge.sdk.awswaf.com/a40627b4876a/b00be2a099fd\"</script></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 398
+          "bodySize": 277
         }
       }
     ]

--- a/providers/funcaptcha/failed.json
+++ b/providers/funcaptcha/failed.json
@@ -8,7 +8,7 @@
     "pages": [
       {
         "id": "page_1",
-        "title": "Les Personas Synthétiques sont-ils la Nouvelle Norme de la Recherche Utilisateur ?",
+        "title": "Verify you are human",
         "startedDateTime": "2026-08-25T13:00:00.000Z",
         "pageTimings": {
           "onContentLoad": -1,
@@ -25,12 +25,12 @@
         "connection": "443",
         "request": {
           "method": "GET",
-          "url": "https://www.delve.ai/fr/blog/personas-synthetiques",
+          "url": "https://share.google/r61H0vQO2WLpfzAgn",
           "httpVersion": "http/1.1",
           "headers": [
             {
               "name": "host",
-              "value": "www.delve.ai"
+              "value": "share.google"
             }
           ],
           "queryString": [],
@@ -50,13 +50,13 @@
           ],
           "cookies": [],
           "content": {
-            "size": 398,
+            "size": 246,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>Les Personas Synthétiques sont-ils la Nouvelle Norme de la Recherche Utilisateur ?</title><style>.c-search-captcha{display:flex}</style></head><body><article><h1>Personas</h1><p>Delve AI has been featured in Gartner's Hype Cycle.</p></article><script src=\"https://hcaptcha.com/1/api.js\"></script></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>Verify you are human</title></head><body><script src=\"https://wbd-api.arkoselabs.com/v2/enforcement.js\"></script></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 398
+          "bodySize": 246
         }
       }
     ]

--- a/providers/funcaptcha/success.json
+++ b/providers/funcaptcha/success.json
@@ -8,7 +8,7 @@
     "pages": [
       {
         "id": "page_1",
-        "title": "Les Personas Synthétiques sont-ils la Nouvelle Norme de la Recherche Utilisateur ?",
+        "title": "4,000-year-old handprint found on ancient Egyptian tomb | CNN",
         "startedDateTime": "2026-08-25T13:00:00.000Z",
         "pageTimings": {
           "onContentLoad": -1,
@@ -25,12 +25,12 @@
         "connection": "443",
         "request": {
           "method": "GET",
-          "url": "https://www.delve.ai/fr/blog/personas-synthetiques",
+          "url": "https://share.google/r61H0vQO2WLpfzAgn",
           "httpVersion": "http/1.1",
           "headers": [
             {
               "name": "host",
-              "value": "www.delve.ai"
+              "value": "share.google"
             }
           ],
           "queryString": [],
@@ -50,13 +50,13 @@
           ],
           "cookies": [],
           "content": {
-            "size": 398,
+            "size": 368,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>Les Personas Synthétiques sont-ils la Nouvelle Norme de la Recherche Utilisateur ?</title><style>.c-search-captcha{display:flex}</style></head><body><article><h1>Personas</h1><p>Delve AI has been featured in Gartner's Hype Cycle.</p></article><script src=\"https://hcaptcha.com/1/api.js\"></script></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>4,000-year-old handprint found on ancient Egyptian tomb | CNN</title></head><body><article><h1>Handprint</h1><p>Archaeologists found a 4,000-year-old handprint.</p></article><script>window.ARKOSE_LOOKUP_SRC=\"https://wbd-api.arkoselabs.com/v2/72361606-06A8-445C-A3D0-9FB07DB14610/api.js\"</script></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 398
+          "bodySize": 368
         }
       }
     ]

--- a/providers/hcaptcha/failed.json
+++ b/providers/hcaptcha/failed.json
@@ -8,8 +8,8 @@
     "pages": [
       {
         "id": "page_1",
-        "title": "Tennis - Gamma Sports",
-        "startedDateTime": "2026-08-25T05:00:00.000Z",
+        "title": "Verify you are human",
+        "startedDateTime": "2026-08-25T13:00:00.000Z",
         "pageTimings": {
           "onContentLoad": -1,
           "onLoad": 100
@@ -19,18 +19,18 @@
     "entries": [
       {
         "pageref": "page_1",
-        "startedDateTime": "2026-08-25T05:00:00.000Z",
+        "startedDateTime": "2026-08-25T13:00:00.000Z",
         "time": 100,
         "serverIPAddress": "",
         "connection": "443",
         "request": {
           "method": "GET",
-          "url": "https://www.gammasports.com/collections/tennis",
+          "url": "https://www.delve.ai/fr/blog/personas-synthetiques",
           "httpVersion": "http/1.1",
           "headers": [
             {
               "name": "host",
-              "value": "www.gammasports.com"
+              "value": "www.delve.ai"
             }
           ],
           "queryString": [],
@@ -50,13 +50,13 @@
           ],
           "cookies": [],
           "content": {
-            "size": 189,
+            "size": 241,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>Tennis - Gamma Sports</title></head><body><script src=\"https://hcaptcha.com/1/api.js\"></script><div class=\"h-captcha\" data-sitekey=\"k\"></div></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>Verify you are human</title></head><body><div class=\"h-captcha\" data-sitekey=\"k\"></div><script src=\"https://hcaptcha.com/1/api.js\"></script></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 189
+          "bodySize": 241
         }
       }
     ]

--- a/src/providers.json
+++ b/src/providers.json
@@ -1022,12 +1022,6 @@
             },
             {
               "contains": "gokuProps"
-            },
-            {
-              "regex": "awswaf\\.com[^\"' ]*challenge"
-            },
-            {
-              "regex": "\\/awswaf\\/[^\"' ]*challenge"
             }
           ]
         },

--- a/src/providers.json
+++ b/src/providers.json
@@ -546,10 +546,21 @@
           "technique": "captcha",
           "rules": [
             {
+              "regex": "^(?=[\\s\\S]*\\bh-captcha(?!-response))(?=[\\s\\S]*(?:Verify you are (?:a )?human|Attention Required|Please verify))",
+              "flags": "i"
+            }
+          ]
+        },
+        {
+          "type": "html",
+          "technique": "captcha",
+          "statusCodes": [403, 429, 503],
+          "rules": [
+            {
               "contains": "hcaptcha.com"
             },
             {
-              "regex": "h-captcha(?!-response)"
+              "regex": "\\bh-captcha(?!-response)"
             }
           ]
         }
@@ -576,6 +587,17 @@
         {
           "type": "html",
           "technique": "captcha",
+          "rules": [
+            {
+              "regex": "^(?=[\\s\\S]*arkoselabs\\.com)(?=[\\s\\S]*(?:Verify you are (?:a )?human|Attention Required|Please verify|enforcement\\.js))",
+              "flags": "i"
+            }
+          ]
+        },
+        {
+          "type": "html",
+          "technique": "captcha",
+          "statusCodes": [403, 429, 503],
           "rules": [
             {
               "contains": "arkoselabs.com"
@@ -675,6 +697,17 @@
         {
           "type": "html",
           "technique": "captcha",
+          "rules": [
+            {
+              "regex": "^(?=[\\s\\S]*frc-captcha)(?=[\\s\\S]*(?:Verify you are (?:a )?human|Attention Required|Please verify))",
+              "flags": "i"
+            }
+          ]
+        },
+        {
+          "type": "html",
+          "technique": "captcha",
+          "statusCodes": [403, 429, 503],
           "rules": [
             {
               "contains": "frc-captcha"
@@ -977,10 +1010,6 @@
             {
               "header": "x-amzn-waf-action",
               "exists": true
-            },
-            {
-              "header": "x-amzn-requestid",
-              "exists": true
             }
           ]
         },
@@ -992,6 +1021,22 @@
               "regex": "aws-waf\\.\\w+\\s*\\("
             },
             {
+              "contains": "gokuProps"
+            },
+            {
+              "regex": "awswaf\\.com[^\"' ]*challenge"
+            },
+            {
+              "regex": "\\/awswaf\\/[^\"' ]*challenge"
+            }
+          ]
+        },
+        {
+          "type": "html",
+          "technique": "javascript",
+          "statusCodes": [202, 403, 405, 429, 503],
+          "rules": [
+            {
               "regex": "awswaf\\.com|\\/awswaf\\/"
             }
           ]
@@ -999,6 +1044,7 @@
         {
           "type": "cookies",
           "technique": "cookie",
+          "statusCodes": [202, 403, 405, 429, 503],
           "rules": [
             {
               "cookie": "aws-waf-token="

--- a/test/index.js
+++ b/test/index.js
@@ -553,11 +553,27 @@ test('hcaptcha (url)', t => {
   t.is(result.provider, 'hcaptcha')
 })
 
-test('hcaptcha (html hcaptcha.com)', t => {
+test('hcaptcha (html hcaptcha.com on a blocking status)', t => {
   const html = '<script src="https://hcaptcha.com/1/api.js"></script>'
-  const result = isAntibot({ html })
-  t.is(result.detected, true)
-  t.is(result.provider, 'hcaptcha')
+  for (const statusCode of [403, 429, 503]) {
+    const result = isAntibot({ html, statusCode })
+    t.is(result.detected, true, `should detect for status ${statusCode}`)
+    t.is(result.provider, 'hcaptcha')
+  }
+})
+
+test('hcaptcha (widget on a 200 content page is not a block)', t => {
+  const html =
+    '<article>real article</article><script src="https://hcaptcha.com/1/api.js"></script><div class="h-captcha"></div>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+})
+
+test('hcaptcha (no false positive for search-captcha CSS)', t => {
+  const html =
+    '<style>.c-search-captcha{display:flex}</style><article>Les Personas Synthétiques</article>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
 })
 
 test('hcaptcha (no false positive for bare hcaptcha mention)', t => {
@@ -566,9 +582,17 @@ test('hcaptcha (no false positive for bare hcaptcha mention)', t => {
   t.is(result.detected, false)
 })
 
-test('hcaptcha (html h-captcha)', t => {
+test('hcaptcha (html h-captcha on a blocking status)', t => {
   const html = '<div class="h-captcha"></div>'
-  const result = isAntibot({ html })
+  const result = isAntibot({ html, statusCode: 403 })
+  t.is(result.detected, true)
+  t.is(result.provider, 'hcaptcha')
+})
+
+test('hcaptcha (Verify you are human interstitial on a 200)', t => {
+  const html =
+    '<title>Verify you are human</title><div class="h-captcha" data-sitekey="k"></div>'
+  const result = isAntibot({ html, statusCode: 200 })
   t.is(result.detected, true)
   t.is(result.provider, 'hcaptcha')
 })
@@ -594,9 +618,9 @@ test('funcaptcha (url with funcaptcha)', t => {
   t.is(result.provider, 'funcaptcha')
 })
 
-test('funcaptcha (html with funcaptcha)', t => {
+test('funcaptcha (html with funcaptcha on a blocking status)', t => {
   const html = '<script>funcaptcha.init();</script>'
-  const result = isAntibot({ html })
+  const result = isAntibot({ html, statusCode: 403 })
   t.is(result.detected, true)
   t.is(result.provider, 'funcaptcha')
 })
@@ -607,10 +631,25 @@ test('funcaptcha (no false positive for bare funcaptcha mention)', t => {
   t.is(result.detected, false)
 })
 
-test('funcaptcha (html with arkoselabs.com)', t => {
+test('funcaptcha (html with arkoselabs.com on a blocking status)', t => {
   const html =
     '<script src="https://client-api.arkoselabs.com/fc/assets/loader.js"></script>'
-  const result = isAntibot({ html })
+  const result = isAntibot({ html, statusCode: 403 })
+  t.is(result.detected, true)
+  t.is(result.provider, 'funcaptcha')
+})
+
+test('funcaptcha (Arkose keys on a 200 content page are not a block)', t => {
+  const html =
+    '<article>CNN story</article><script>window.ARKOSE_LOOKUP_SRC="https://wbd-api.arkoselabs.com/v2/key/api.js"</script>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+})
+
+test('funcaptcha (Verify you are human interstitial on a 200)', t => {
+  const html =
+    '<title>Verify you are human</title><script src="https://client-api.arkoselabs.com/v2/api.js"></script>'
+  const result = isAntibot({ html, statusCode: 200 })
   t.is(result.detected, true)
   t.is(result.provider, 'funcaptcha')
 })
@@ -700,16 +739,23 @@ test('friendly-captcha (url)', t => {
   t.is(result.provider, 'friendly-captcha')
 })
 
-test('friendly-captcha (html frc-captcha)', t => {
+test('friendly-captcha (html frc-captcha on a blocking status)', t => {
   const html = '<div class="frc-captcha" data-sitekey="test"></div>'
-  const result = isAntibot({ html })
+  const result = isAntibot({ html, statusCode: 403 })
   t.is(result.detected, true)
   t.is(result.provider, 'friendly-captcha')
 })
 
-test('friendly-captcha (html friendlyChallenge)', t => {
+test('friendly-captcha (widget on a 200 content page is not a block)', t => {
+  const html =
+    '<article>real article</article><div class="frc-captcha" data-sitekey="test"></div>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+})
+
+test('friendly-captcha (html friendlyChallenge on a blocking status)', t => {
   const html = '<script>friendlyChallenge.render();</script>'
-  const result = isAntibot({ html })
+  const result = isAntibot({ html, statusCode: 403 })
   t.is(result.detected, true)
   t.is(result.provider, 'friendly-captcha')
 })
@@ -1143,6 +1189,16 @@ test('aws-waf (header)', t => {
   t.is(result.technique, 'javascript')
 })
 
+test('aws-waf (x-amzn-requestid on a 200 is not a block)', t => {
+  const headers = { 'x-amzn-requestid': 'ee270925-a72c-4312-a2c7-c680bc157787' }
+  const result = isAntibot({
+    headers,
+    statusCode: 200,
+    html: '<article>Genesis -part 9</article>'
+  })
+  t.is(result.detected, false)
+})
+
 test('aws-waf (html aws-waf)', t => {
   const html = '<script>aws-waf.init();</script>'
   const result = isAntibot({ html })
@@ -1150,11 +1206,18 @@ test('aws-waf (html aws-waf)', t => {
   t.is(result.provider, 'aws-waf')
 })
 
-test('aws-waf (html awswaf)', t => {
+test('aws-waf (html awswaf challenge)', t => {
   const html = '<script src="/awswaf/challenge.js"></script>'
   const result = isAntibot({ html })
   t.is(result.detected, true)
   t.is(result.provider, 'aws-waf')
+})
+
+test('aws-waf (SDK integration URL on a 200 is not a block)', t => {
+  const html =
+    '<script>window.WEB_ACL_INTEGRATION_URL="https://a40627b4876a.edge.sdk.awswaf.com/a40627b4876a/b00be2a099fd"</script><article>checkout</article>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
 })
 
 test('aws-waf (no false positive for bare mention)', t => {
@@ -1163,11 +1226,21 @@ test('aws-waf (no false positive for bare mention)', t => {
   t.is(result.detected, false)
 })
 
-test('aws-waf (aws-waf-token set-cookie)', t => {
+test('aws-waf (aws-waf-token set-cookie on a blocking status)', t => {
   const headers = { 'set-cookie': 'aws-waf-token=abc123; path=/' }
-  const result = isAntibot({ headers })
+  const result = isAntibot({ headers, statusCode: 403 })
   t.is(result.detected, true)
   t.is(result.provider, 'aws-waf')
+})
+
+test('aws-waf (aws-waf-token leftover on a 200 is not a block)', t => {
+  const headers = { 'set-cookie': 'aws-waf-token=abc123; path=/' }
+  const result = isAntibot({
+    headers,
+    statusCode: 200,
+    html: '<article>ok</article>'
+  })
+  t.is(result.detected, false)
 })
 
 test('createTestPattern with invalid regex catches error', t => {
@@ -1230,7 +1303,8 @@ test('support Fetch Response with await text()', async t => {
 
 test('fallback body string to html', t => {
   const result = isAntibot({
-    body: '<script src="https://hcaptcha.com/1/api.js"></script>'
+    body: '<script src="https://hcaptcha.com/1/api.js"></script>',
+    statusCode: 403
   })
   t.is(result.detected, true)
   t.is(result.provider, 'hcaptcha')

--- a/test/index.js
+++ b/test/index.js
@@ -1206,11 +1206,18 @@ test('aws-waf (html aws-waf)', t => {
   t.is(result.provider, 'aws-waf')
 })
 
-test('aws-waf (html awswaf challenge)', t => {
+test('aws-waf (html awswaf challenge.js on a blocking status)', t => {
   const html = '<script src="/awswaf/challenge.js"></script>'
-  const result = isAntibot({ html })
+  const result = isAntibot({ html, statusCode: 403 })
   t.is(result.detected, true)
   t.is(result.provider, 'aws-waf')
+})
+
+test('aws-waf (SDK challenge.js on a 200 is not a block)', t => {
+  const html =
+    '<script src="https://a40627b4876a.edge.sdk.awswaf.com/a40627b4876a/challenge.js" defer></script><article>checkout</article>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
 })
 
 test('aws-waf (SDK integration URL on a 200 is not a block)', t => {
@@ -1218,6 +1225,13 @@ test('aws-waf (SDK integration URL on a 200 is not a block)', t => {
     '<script>window.WEB_ACL_INTEGRATION_URL="https://a40627b4876a.edge.sdk.awswaf.com/a40627b4876a/b00be2a099fd"</script><article>checkout</article>'
   const result = isAntibot({ html, statusCode: 200 })
   t.is(result.detected, false)
+})
+
+test('aws-waf (gokuProps interstitial on a 200)', t => {
+  const html = '<script>window.gokuProps={"key":"k"}</script>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, true)
+  t.is(result.provider, 'aws-waf')
 })
 
 test('aws-waf (no false positive for bare mention)', t => {


### PR DESCRIPTION
## Summary
- AWS WAF treated `x-amzn-requestid` and `awswaf.com` SDK URLs as a challenge. Those are on every API Gateway / checkout 200 (Spreaker, Hotmart).
- hCaptcha / FunCaptcha / Friendly Captcha treated a widget embed as a block. Same class of bug Turnstile already shipped in 2.5.2 (`search-captcha` CSS even matched `h-captcha`).
- Gate the fingerprints on a blocking status (copy recaptcha/Turnstile). Keep `x-amzn-waf-action`, `gokuProps` / `challenge.js`, and a 200 interstitial title as the real signals.

Production since api@3.52.11: **20.1 scrape.do units per API request**. AWS WAF 16.8% of spend with 22/289 hops resolved; hCaptcha 10.0% with 6/147. Four live captures (delve.ai, Spreaker, Hotmart, share.google) are thousands of characters of real content and `detected: true` on 2.5.2 — `detected: false` after this change. A 4-hop climb that already had a 200 is 41 units before, 1 after.

## Test plan
- [x] `pnpm test` (199 passed)
- [x] Replay captured 200s: delve.ai / Spreaker / Hotmart / share.google → no provider
- [ ] After merge: npm release **and** `is-antibot` dep bump in microlink-api. A merged PR is not a deployed fix.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded detection for AWS WAF, hCaptcha, FunCaptcha, and Friendly Captcha challenge pages.
  * Added recognition for human-verification interstitials and additional AWS WAF challenge indicators.

* **Bug Fixes**
  * Reduced false positives by requiring relevant challenge signals to occur with blocking HTTP status codes.

* **Tests**
  * Added and refreshed verification scenarios covering successful pages, failed challenges, and non-blocking responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->