### PR TITLE
ci: do not fail release when downstream dispatch 404s

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
           fi
       - name: Dispatch release event
         if: steps.release.outputs.released == 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- The [latest release](https://github.com/microlinkhq/is-antibot/actions/runs/32856655156/job/97830266513) published **2.5.3** and then failed on `Dispatch release event`: `gh api repos/musantro/is-antibot/dispatches` → 404.
- [musantro/is-antibot](https://github.com/musantro/is-antibot) exists (Python port). GitHub returns 404 when the token cannot create a `repository_dispatch` there — `secrets.GH_TOKEN` is a microlink token, not a musantro one.
- `continue-on-error: true` so a successful npm publish is not marked failed. Dispatch is still attempted.

To actually notify the Python port, `GH_TOKEN` needs `contents: write` on `musantro/is-antibot`.

## Test plan
- [ ] Next `fix:`/`feat:` master push: Release job stays green after publish
- [ ] Dispatch step may still show a warning if the token has no access


Made with [Cursor](https://cursor.com)