### PR TITLE
fix: ignore Arkose Please verify on content pages

### DIFF
--- a/providers/funcaptcha/success.json
+++ b/providers/funcaptcha/success.json
@@ -56,7 +56,7 @@
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 368
+          "bodySize": 320
         }
       }
     ]

--- a/providers/funcaptcha/success.json
+++ b/providers/funcaptcha/success.json
@@ -50,9 +50,9 @@
           ],
           "cookies": [],
           "content": {
-            "size": 368,
+            "size": 320,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>4,000-year-old handprint found on ancient Egyptian tomb | CNN</title></head><body><article><h1>Handprint</h1><p>Archaeologists found a 4,000-year-old handprint.</p></article><script>window.ARKOSE_LOOKUP_SRC=\"https://wbd-api.arkoselabs.com/v2/72361606-06A8-445C-A3D0-9FB07DB14610/api.js\"</script></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>4,000-year-old handprint found on ancient Egyptian tomb | CNN</title></head><body><article><h1>Handprint</h1><p>AI-generated content. Please verify before relying on it.</p></article><script>const allow=[\"microsoft-api.arkoselabs.com\",\"challenges.cloudflare.com\"]</script></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,

--- a/src/providers.json
+++ b/src/providers.json
@@ -589,7 +589,7 @@
           "technique": "captcha",
           "rules": [
             {
-              "regex": "^(?=[\\s\\S]*arkoselabs\\.com)(?=[\\s\\S]*(?:Verify you are (?:a )?human|Attention Required|Please verify|enforcement\\.js))",
+              "regex": "^(?=[\\s\\S]*arkoselabs\\.com)(?=[\\s\\S]*(?:Verify you are (?:a )?human|Attention Required|enforcement\\.js))",
               "flags": "i"
             }
           ]

--- a/test/index.js
+++ b/test/index.js
@@ -646,6 +646,15 @@ test('funcaptcha (Arkose keys on a 200 content page are not a block)', t => {
   t.is(result.detected, false)
 })
 
+test('funcaptcha (Please verify disclaimer + arkose allowlist on 200 is not a block)', t => {
+  const html =
+    '<title>daily calm video for support group - Search Videos</title>' +
+    '<p>AI-generated content. Please verify before relying on it.</p>' +
+    '<script>const allow=["microsoft-api.arkoselabs.com","challenges.cloudflare.com"]</script>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+})
+
 test('funcaptcha (Verify you are human interstitial on a 200)', t => {
   const html =
     '<title>Verify you are human</title><script src="https://client-api.arkoselabs.com/v2/api.js"></script>'


### PR DESCRIPTION
## Summary
- Bing (and any page) listing `arkoselabs.com` in a CSP allowlist plus an AI disclaimer (`Please verify before relying on it`) was flagged as FunCaptcha on a 200.
- Drop `Please verify` from the 200-path HTML rule. Keep `Verify you are human` / `enforcement.js` for real interstitials. Status-gated `arkoselabs.com` / `funcaptcha.x(` on 403/429/503 is unchanged.
- Replay of a captured Bing videos 200: **detected before, not after**. No next-provider fallthrough. Failed fixture still detects.

## Test plan
- [x] `ava test/index.js test/providers.js` (171 passed)
- [x] Replay captured Bing HTML against old vs new rule
- [ ] After merge: npm release `is-antibot` **and** dep bump in `microlink-api` — a merged PR is not a deployed fix


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved challenge-page detection to avoid falsely identifying “Please verify” disclaimers as access blocks.
  * Updated handling of pages containing Arkose and Cloudflare allowlisted domains.

* **Tests**
  * Added regression coverage to confirm legitimate responses with these disclaimers are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->