### PR TITLE
fix: ignore PerimeterX sensor snippet on content pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -158,7 +158,7 @@ Each provider has unique fingerprints across one or more of these signals. The l
       <tr><td>LinkedIn</td><td>Platform-specific</td><td>1</td><td><span class="provider-chip">Status Code</span></td></tr>
       <tr><td>Meetrics</td><td>Antibot</td><td>2</td><td><span class="provider-chip">HTML</span><span class="provider-chip">URL</span></td></tr>
       <tr><td>Ocule</td><td>Antibot</td><td>2</td><td><span class="provider-chip">HTML</span><span class="provider-chip">URL</span></td></tr>
-      <tr><td>PerimeterX</td><td>Antibot</td><td>3</td><td><span class="provider-chip">Headers</span><span class="provider-chip">Cookies</span><span class="provider-chip">HTML</span></td></tr>
+      <tr><td>PerimeterX</td><td>Antibot</td><td>4</td><td><span class="provider-chip">Headers</span><span class="provider-chip">Cookies</span><span class="provider-chip">HTML</span><span class="provider-chip">URL</span></td></tr>
       <tr><td>QCloud Captcha</td><td>CAPTCHA</td><td>2</td><td><span class="provider-chip">HTML</span><span class="provider-chip">URL</span></td></tr>
       <tr><td>Reblaze</td><td>Antibot</td><td>2</td><td><span class="provider-chip">Cookies</span><span class="provider-chip">HTML</span></td></tr>
       <tr><td>reCAPTCHA</td><td>CAPTCHA</td><td>2</td><td><span class="provider-chip">HTML</span><span class="provider-chip">URL</span></td></tr>

--- a/providers/perimeterx/failed.json
+++ b/providers/perimeterx/failed.json
@@ -1,0 +1,64 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "microlink-api",
+      "version": "1.0.0"
+    },
+    "pages": [
+      {
+        "id": "page_1",
+        "title": "Robot or human?",
+        "startedDateTime": "2026-08-26T05:33:00.000Z",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": 100
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2026-08-26T05:33:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
+        "connection": "443",
+        "request": {
+          "method": "GET",
+          "url": "https://www.walmart.com/ip/Coolcold-15-6-17-3inch-Laptop-Cooling-Pad-with-6-Quiet-Fans-7-Height-Wind-Speed-Adjustable-2-USB-Port-Laptop-Cooer-With-Mobile-Phone-Holde/3031434175",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "host",
+              "value": "www.walmart.com"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 327,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html><head><title>Robot or human?</title></head><body><h1>Robot or human?</h1><p>Activate and hold the button to confirm that you’re human. Thank You!</p><div id=\"px-captcha\"></div><script>window._pxAppId='PXu6b0qd2S';var captchajs='/px/'+window._pxAppId+'/captcha/captcha.js?a=c&m=0&g=b'</script></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 327
+        }
+      }
+    ]
+  }
+}

--- a/providers/perimeterx/failed.json
+++ b/providers/perimeterx/failed.json
@@ -56,7 +56,7 @@
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 329,
+          "bodySize": 329
         }
       }
     ]

--- a/providers/perimeterx/failed.json
+++ b/providers/perimeterx/failed.json
@@ -50,13 +50,13 @@
           ],
           "cookies": [],
           "content": {
-            "size": 327,
+            "size": 329,
             "mimeType": "text/html",
             "text": "<!DOCTYPE html><html><head><title>Robot or human?</title></head><body><h1>Robot or human?</h1><p>Activate and hold the button to confirm that you’re human. Thank You!</p><div id=\"px-captcha\"></div><script>window._pxAppId='PXu6b0qd2S';var captchajs='/px/'+window._pxAppId+'/captcha/captcha.js?a=c&m=0&g=b'</script></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 327
+          "bodySize": 329,
         }
       }
     ]

--- a/providers/perimeterx/success.json
+++ b/providers/perimeterx/success.json
@@ -1,0 +1,64 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "microlink-api",
+      "version": "1.0.0"
+    },
+    "pages": [
+      {
+        "id": "page_1",
+        "title": "Coolcold Laptop Cooling Pad - Walmart.com",
+        "startedDateTime": "2026-08-26T05:33:00.000Z",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": 100
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2026-08-26T05:33:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
+        "connection": "443",
+        "request": {
+          "method": "GET",
+          "url": "https://www.walmart.com/ip/Coolcold-15-6-17-3inch-Laptop-Cooling-Pad-with-6-Quiet-Fans-7-Height-Wind-Speed-Adjustable-2-USB-Port-Laptop-Cooer-With-Mobile-Phone-Holde/3031434175",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "host",
+              "value": "www.walmart.com"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 297,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html><head><title>Coolcold Laptop Cooling Pad - Walmart.com</title></head><body><article><h1>Coolcold Laptop Cooling Pad</h1><p>6 Quiet Fans, 7 Height adjustable.</p></article><script>window._pxAppId='PXu6b0qd2S'</script><script src=\"/px/PXu6b0qd2S/init.js\"></script></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 297
+        }
+      }
+    ]
+  }
+}

--- a/src/providers.json
+++ b/src/providers.json
@@ -151,13 +151,21 @@
           "technique": "javascript",
           "rules": [
             {
-              "contains": "window._pxAppId"
-            },
-            {
-              "contains": "pxInit"
+              "regex": "^(?=[\\s\\S]*window\\._pxAppId)(?=[\\s\\S]*(?:px-captcha|/captcha/captcha\\.js|_pxAction|Robot or human))",
+              "flags": "i"
             },
             {
               "contains": "_pxAction"
+            }
+          ]
+        },
+        {
+          "type": "url",
+          "technique": "javascript",
+          "domain": "walmart.com",
+          "rules": [
+            {
+              "contains": "/blocked?"
             }
           ]
         },

--- a/src/providers.json
+++ b/src/providers.json
@@ -151,7 +151,7 @@
           "technique": "javascript",
           "rules": [
             {
-              "regex": "^(?=[\\s\\S]*window\\._pxAppId)(?=[\\s\\S]*(?:px-captcha|/captcha/captcha\\.js|_pxAction|Robot or human))",
+              "regex": "^(?=[\\s\\S]*window\\._pxAppId)(?=[\\s\\S]*(?:px-captcha|/captcha/captcha\\.js|_pxAction|<title\\b[^>]*>\\s*Robot or human\\??\\s*<\\/title>))",
               "flags": "i"
             },
             {

--- a/test/index.js
+++ b/test/index.js
@@ -171,6 +171,13 @@ test('perimeterx (no false positive for pxInit on a content page)', t => {
   t.is(result.detected, false)
 })
 
+test('perimeterx (no false positive for Robot or human in page copy)', t => {
+  const html =
+    '<title>Coolcold Laptop Cooling Pad - Walmart.com</title><p>Robot or human? Great cooling pad.</p><script>window._pxAppId="PXu6b0qd2S"</script>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+})
+
 test('perimeterx (walmart /blocked url)', t => {
   const result = isAntibot({
     url: 'https://www.walmart.com/blocked?url=L2lwL3Rlc3Q&uuid=1',

--- a/test/index.js
+++ b/test/index.js
@@ -141,18 +141,13 @@ test('perimeterx (header)', t => {
   t.is(result.provider, 'perimeterx')
 })
 
-test('perimeterx (html window._pxAppId)', t => {
-  const html = '<script>window._pxAppId = "PX123";</script>'
-  const result = isAntibot({ html })
+test('perimeterx (html hold-button challenge)', t => {
+  const html =
+    '<title>Robot or human?</title><div id="px-captcha"></div><script>window._pxAppId="PXu6b0qd2S";var captchajs="/px/"+window._pxAppId+"/captcha/captcha.js"</script>'
+  const result = isAntibot({ html, statusCode: 200 })
   t.is(result.detected, true)
   t.is(result.provider, 'perimeterx')
-})
-
-test('perimeterx (html pxInit)', t => {
-  const html = '<script>pxInit();</script>'
-  const result = isAntibot({ html })
-  t.is(result.detected, true)
-  t.is(result.provider, 'perimeterx')
+  t.is(result.detection, 'html')
 })
 
 test('perimeterx (html _pxAction)', t => {
@@ -160,6 +155,30 @@ test('perimeterx (html _pxAction)', t => {
   const result = isAntibot({ html })
   t.is(result.detected, true)
   t.is(result.provider, 'perimeterx')
+})
+
+test('perimeterx (no false positive for sensor snippet on a content page)', t => {
+  const html =
+    '<title>Coolcold Laptop Cooling Pad - Walmart.com</title><article>6 Quiet Fans</article><script>window._pxAppId=\'PXu6b0qd2S\'</script><script src="/px/PXu6b0qd2S/init.js"></script>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
+})
+
+test('perimeterx (no false positive for pxInit on a content page)', t => {
+  const html = '<title>Product</title><script>pxInit();</script>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+})
+
+test('perimeterx (walmart /blocked url)', t => {
+  const result = isAntibot({
+    url: 'https://www.walmart.com/blocked?url=L2lwL3Rlc3Q&uuid=1',
+    statusCode: 200
+  })
+  t.is(result.detected, true)
+  t.is(result.provider, 'perimeterx')
+  t.is(result.detection, 'url')
 })
 
 test('perimeterx (_px3 set-cookie)', t => {


### PR DESCRIPTION
## Summary
- `window._pxAppId` / `pxInit` are the HUMAN/PX **sensor**, not a challenge. They ship on successful Walmart (and other PX) 200s, so scrape.do product pages never `resolved` and the domain is marked proxy-exhausted for 7 days.
- HTML detection now requires the hold-button challenge (`px-captcha`, `captcha/captcha.js`, `_pxAction`, or `Robot or human?`) together with the sensor. Walmart `/blocked?` is also a URL signal.
- Adds `providers/perimeterx/{success,failed}.json`: same product URL, both 200, both carrying `_pxAppId`; only the failed body has the challenge signature.

## Test plan
- [x] `pnpm test` (205 passing)
- [x] Captured scrape.do datacenter 200 (real product HTML) → `detected: false`
- [x] Captured `/blocked` "Robot or human?" page → `detected: true`
- [ ] After npm publish, bump `is-antibot` on microlink-api and clear `walmart.com` from `proxyExhaustedCache` (set 2026-08-22, 7d TTL)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection of PerimeterX challenges in page content.
  * Added detection for Walmart blocked-page URLs.

* **Bug Fixes**
  * Reduced false positives from ordinary PerimeterX sensor and initialization scripts.
  * More accurately identifies CAPTCHA and challenge pages.

* **Tests**
  * Added coverage for challenge HTML, blocked URLs, and successful product pages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->