### PR TITLE
fix: ignore QCloud Captcha widget on content pages

### DIFF
--- a/providers/qcloud-captcha/failed.json
+++ b/providers/qcloud-captcha/failed.json
@@ -1,0 +1,64 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "microlink-api",
+      "version": "1.0.0"
+    },
+    "pages": [
+      {
+        "id": "page_1",
+        "title": "请点击按钮开始验证",
+        "startedDateTime": "2026-08-26T10:02:00.000Z",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": 100
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2026-08-26T10:02:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
+        "connection": "443",
+        "request": {
+          "method": "GET",
+          "url": "https://www.donews.com/news/detail/1/6151122.html",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "host",
+              "value": "www.donews.com"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 196,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html><head><title>请点击按钮开始验证</title></head><body><div id=\"TencentCaptcha\"></div><script src=\"https://turing.captcha.qcloud.com/TCaptcha.js\"></script></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 196
+        }
+      }
+    ]
+  }
+}

--- a/providers/qcloud-captcha/success.json
+++ b/providers/qcloud-captcha/success.json
@@ -1,0 +1,64 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "microlink-api",
+      "version": "1.0.0"
+    },
+    "pages": [
+      {
+        "id": "page_1",
+        "title": "京东发布AI 全景图，未来三年持续投入构建万亿人工智能生态- DoNews",
+        "startedDateTime": "2026-08-26T10:02:00.000Z",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": 100
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2026-08-26T10:02:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
+        "connection": "443",
+        "request": {
+          "method": "GET",
+          "url": "https://www.donews.com/news/detail/1/6151122.html",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "host",
+              "value": "www.donews.com"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 418,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html><head><title>京东发布AI 全景图，未来三年持续投入构建万亿人工智能生态- DoNews</title></head><body><article><h1>京东发布AI 全景图</h1><p>京东发布AI 全景图，未来三年持续投入构建万亿人工智能生态。</p></article><span id=\"TencentCaptcha\">获取验证码</span><script src=\"https://turing.captcha.qcloud.com/TCaptcha.js\"></script></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 418
+        }
+      }
+    ]
+  }
+}

--- a/src/providers.json
+++ b/src/providers.json
@@ -786,6 +786,17 @@
           "technique": "captcha",
           "rules": [
             {
+              "regex": "^(?=[\\s\\S]*(?:TencentCaptcha|turing\\.captcha))(?=[\\s\\S]*(?:请点击按钮开始验证|请完成安全验证|tcaptcha_transform))",
+              "flags": "i"
+            }
+          ]
+        },
+        {
+          "type": "html",
+          "technique": "captcha",
+          "statusCodes": [403, 429, 503],
+          "rules": [
+            {
               "contains": "TencentCaptcha"
             },
             {

--- a/test/index.js
+++ b/test/index.js
@@ -840,16 +840,33 @@ test('qcloud-captcha (url)', t => {
   t.is(result.provider, 'qcloud-captcha')
 })
 
-test('qcloud-captcha (html TencentCaptcha)', t => {
+test('qcloud-captcha (html TencentCaptcha on a blocking status)', t => {
   const html = '<script>new TencentCaptcha("appid");</script>'
-  const result = isAntibot({ html })
+  for (const statusCode of [403, 429, 503]) {
+    const result = isAntibot({ html, statusCode })
+    t.is(result.detected, true, `should detect for status ${statusCode}`)
+    t.is(result.provider, 'qcloud-captcha')
+  }
+})
+
+test('qcloud-captcha (widget on a 200 content page is not a block)', t => {
+  const html =
+    '<article>real article</article><span id="TencentCaptcha">获取验证码</span><script src="https://turing.captcha.qcloud.com/TCaptcha.js"></script>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+})
+
+test('qcloud-captcha (html turing.captcha on a blocking status)', t => {
+  const html = '<script src="//turing.captcha.gtimg.com/tdc.js"></script>'
+  const result = isAntibot({ html, statusCode: 403 })
   t.is(result.detected, true)
   t.is(result.provider, 'qcloud-captcha')
 })
 
-test('qcloud-captcha (html turing.captcha)', t => {
-  const html = '<script src="//turing.captcha.gtimg.com/tdc.js"></script>'
-  const result = isAntibot({ html })
+test('qcloud-captcha (interstitial on a 200)', t => {
+  const html =
+    '<title>请点击按钮开始验证</title><div id="TencentCaptcha"></div><script src="https://turing.captcha.qcloud.com/TCaptcha.js"></script>'
+  const result = isAntibot({ html, statusCode: 200 })
   t.is(result.detected, true)
   t.is(result.provider, 'qcloud-captcha')
 })


### PR DESCRIPTION
## Summary
- News/article pages that embed TencentCaptcha for comment or SMS login (donews.com, 53ai.com) were flagged as a challenge on HTTP 200, so the proxy ladder kept climbing after it already had the article.
- Gate the bare `TencentCaptcha` / `turing.captcha` fingerprint on 403/429/503. On 200, require the real interstitial copy (`请点击按钮开始验证` / `请完成安全验证` / `tcaptcha_transform`). Same shape as Turnstile (#65).
- Captured 200s now resolve: donews and 53ai go from `detected: true` to `detected: false`, and do not fall through to another provider.

## Test plan
- [x] `ava test/index.js test/providers.js` (178 passed)
- [x] Replay captured datacenter 200s against the new rules


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QCloud CAPTCHA detection to more accurately identify blocked verification pages.
  * Reduced false positives when normal content pages contain embedded CAPTCHA widgets.
  * Added support for recognizing Chinese verification prompts and Tencent CAPTCHA interstitials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->