### PR TITLE
fix: ignore vendor fingerprints on content pages

### DIFF
--- a/providers/cheq/failed.json
+++ b/providers/cheq/failed.json
@@ -8,8 +8,8 @@
     "pages": [
       {
         "id": "page_1",
-        "title": "Verify you are human",
-        "startedDateTime": "2026-08-25T13:00:00.000Z",
+        "title": "Access Denied",
+        "startedDateTime": "2026-08-27T07:00:00.000Z",
         "pageTimings": {
           "onContentLoad": -1,
           "onLoad": 100
@@ -19,18 +19,18 @@
     "entries": [
       {
         "pageref": "page_1",
-        "startedDateTime": "2026-08-25T13:00:00.000Z",
+        "startedDateTime": "2026-08-27T07:00:00.000Z",
         "time": 100,
         "serverIPAddress": "",
         "connection": "443",
         "request": {
           "method": "GET",
-          "url": "https://www.delve.ai/fr/blog/personas-synthetiques",
+          "url": "https://www.purestorage.com/products/block-file-object-storage.html",
           "httpVersion": "http/1.1",
           "headers": [
             {
               "name": "host",
-              "value": "www.delve.ai"
+              "value": "www.purestorage.com"
             }
           ],
           "queryString": [],
@@ -39,8 +39,8 @@
           "bodySize": 0
         },
         "response": {
-          "status": 200,
-          "statusText": "OK",
+          "status": 403,
+          "statusText": "Forbidden",
           "httpVersion": "http/1.1",
           "headers": [
             {
@@ -50,13 +50,13 @@
           ],
           "cookies": [],
           "content": {
-            "size": 188,
+            "size": 191,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>Verify you are human</title></head><body><div class=\"h-captcha\" data-sitekey=\"k\"></div><script src=\"https://hcaptcha.com/1/api.js\"></script></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>Access Denied</title></head><body><p>Access Denied</p><script>CheqSdk.init();</script><script src=\"https://ob.cheqzone.com/script.js\"></script></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 188
+          "bodySize": 191
         }
       }
     ]

--- a/providers/cheq/success.json
+++ b/providers/cheq/success.json
@@ -8,8 +8,8 @@
     "pages": [
       {
         "id": "page_1",
-        "title": "Verify you are human",
-        "startedDateTime": "2026-08-25T13:00:00.000Z",
+        "title": "FlashArray: Unified Block, File, and Object Storage Platform | Everpure",
+        "startedDateTime": "2026-08-27T07:00:00.000Z",
         "pageTimings": {
           "onContentLoad": -1,
           "onLoad": 100
@@ -19,18 +19,18 @@
     "entries": [
       {
         "pageref": "page_1",
-        "startedDateTime": "2026-08-25T13:00:00.000Z",
+        "startedDateTime": "2026-08-27T07:00:00.000Z",
         "time": 100,
         "serverIPAddress": "",
         "connection": "443",
         "request": {
           "method": "GET",
-          "url": "https://www.delve.ai/fr/blog/personas-synthetiques",
+          "url": "https://www.purestorage.com/products/block-file-object-storage.html",
           "httpVersion": "http/1.1",
           "headers": [
             {
               "name": "host",
-              "value": "www.delve.ai"
+              "value": "www.purestorage.com"
             }
           ],
           "queryString": [],
@@ -50,13 +50,13 @@
           ],
           "cookies": [],
           "content": {
-            "size": 188,
+            "size": 275,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>Verify you are human</title></head><body><div class=\"h-captcha\" data-sitekey=\"k\"></div><script src=\"https://hcaptcha.com/1/api.js\"></script></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>FlashArray: Unified Block, File, and Object Storage Platform | Everpure</title><link rel=\"preconnect\" href=\"//obs.cheqzone.com\"/></head><body><article><h1>FlashArray</h1><p>Unified block, file, and object storage.</p></article></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 188
+          "bodySize": 275
         }
       }
     ]

--- a/providers/hcaptcha/success.json
+++ b/providers/hcaptcha/success.json
@@ -50,13 +50,13 @@
           ],
           "cookies": [],
           "content": {
-            "size": 398,
+            "size": 354,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>Les Personas Synthétiques sont-ils la Nouvelle Norme de la Recherche Utilisateur ?</title><style>.c-search-captcha{display:flex}</style></head><body><article><h1>Personas</h1><p>Delve AI has been featured in Gartner's Hype Cycle.</p></article><script src=\"https://hcaptcha.com/1/api.js\"></script></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>Les Personas Synthétiques sont-ils la Nouvelle Norme de la Recherche Utilisateur ?</title></head><body><article><h1>Personas</h1><p>Delve AI has been featured in Gartner's Hype Cycle.</p></article><div class=\"h-captcha\" data-sitekey=\"k\"></div><script>const copy=\"Please verify your email address\"</script></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 398
+          "bodySize": 354
         }
       }
     ]

--- a/providers/recaptcha/failed.json
+++ b/providers/recaptcha/failed.json
@@ -8,100 +8,55 @@
     "pages": [
       {
         "id": "page_1",
-        "title": "https://www.youtube.com/watch?v=EkdXGPGciUY",
-        "startedDateTime": "2026-03-27T17:28:46.000Z",
+        "title": "https://dimiexpress.com.br/",
+        "startedDateTime": "2026-08-27T07:00:00.000Z",
         "pageTimings": {
           "onContentLoad": -1,
-          "onLoad": 150.0
+          "onLoad": 100
         }
       }
     ],
     "entries": [
       {
         "pageref": "page_1",
-        "startedDateTime": "2026-03-27T17:28:46.000Z",
-        "time": 150.0,
-        "serverIPAddress": "104.28.158.82",
+        "startedDateTime": "2026-08-27T07:00:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
         "connection": "443",
         "request": {
           "method": "GET",
-          "url": "https://www.youtube.com/watch?v=EkdXGPGciUY",
-          "httpVersion": "http/2.0",
+          "url": "https://dimiexpress.com.br/",
+          "httpVersion": "http/1.1",
           "headers": [
             {
               "name": "host",
-              "value": "www.youtube.com"
-            },
-            {
-              "name": "user-agent",
-              "value": "Mozilla/5.0 (iPhone; CPU iPhone OS 26_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1"
-            },
-            {
-              "name": "accept",
-              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+              "value": "dimiexpress.com.br"
             }
           ],
-          "queryString": [
-            {
-              "name": "v",
-              "value": "EkdXGPGciUY"
-            }
-          ],
+          "queryString": [],
           "cookies": [],
           "headersSize": -1,
           "bodySize": 0
         },
         "response": {
-          "status": 429,
-          "statusText": "Too Many Requests",
-          "httpVersion": "http/2.0",
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
           "headers": [
             {
-              "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache, must-revalidate"
-            },
-            {
-              "name": "content-length",
-              "value": "3219"
-            },
-            {
               "name": "content-type",
-              "value": "text/html"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 27 Mar 2026 17:28:46 GMT"
-            },
-            {
-              "name": "expires",
-              "value": "Fri, 01 Jan 1990 00:00:00 GMT"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "server",
-              "value": "scaffolding on HTTPServer2"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "0"
+              "value": "text/html; charset=utf-8"
             }
           ],
           "cookies": [],
           "content": {
-            "size": 3219,
+            "size": 204,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>https://www.youtube.com/watch?v=EkdXGPGciUY</title></head><body><form id=\"captcha-form\" action=\"index\" method=\"post\"><script src=\"https://www.google.com/recaptcha/enterprise.js\" async defer></script><div id=\"recaptcha\" class=\"g-recaptcha\" data-sitekey=\"6LfwuyUTAAAAAOAmoS0fdqijC2PbbdH4kjq62Y1b\"></div></form></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>https://dimiexpress.com.br/</title></head><body><form id=\"captcha-form\" action=\"index\" method=\"post\"><div class=\"g-recaptcha\" data-sitekey=\"k\"></div></form></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": -1
+          "bodySize": 204
         }
       }
     ]

--- a/providers/recaptcha/success.json
+++ b/providers/recaptcha/success.json
@@ -8,8 +8,8 @@
     "pages": [
       {
         "id": "page_1",
-        "title": "온라인 학교폭력의 실태",
-        "startedDateTime": "2026-08-25T05:00:00.000Z",
+        "title": "Transporte em Guarulhos - Jávai Logística",
+        "startedDateTime": "2026-08-27T07:00:00.000Z",
         "pageTimings": {
           "onContentLoad": -1,
           "onLoad": 100
@@ -19,26 +19,21 @@
     "entries": [
       {
         "pageref": "page_1",
-        "startedDateTime": "2026-08-25T05:00:00.000Z",
+        "startedDateTime": "2026-08-27T07:00:00.000Z",
         "time": 100,
         "serverIPAddress": "",
         "connection": "443",
         "request": {
           "method": "GET",
-          "url": "http://www.jeonmin.co.kr/news/articleView.html?idxno=353270",
+          "url": "https://dimiexpress.com.br/",
           "httpVersion": "http/1.1",
           "headers": [
             {
               "name": "host",
-              "value": "www.jeonmin.co.kr"
+              "value": "dimiexpress.com.br"
             }
           ],
-          "queryString": [
-            {
-              "name": "idxno",
-              "value": "353270"
-            }
-          ],
+          "queryString": [],
           "cookies": [],
           "headersSize": -1,
           "bodySize": 0
@@ -55,13 +50,13 @@
           ],
           "cookies": [],
           "content": {
-            "size": 298,
+            "size": 281,
             "mimeType": "text/html",
-            "text": "<!DOCTYPE html><html><head><title>온라인 학교폭력의 실태</title></head><body><article><h1>사이버 불링</h1><p>학교폭력의 실태를 다룬 기사입니다.</p></article><input id=\"g-recaptcha-response\" name=\"g-recaptcha-response\" type=\"hidden\" value=\"\" /><script>grecaptcha.render('captcha_container', {sitekey: 'k'})</script></body></html>"
+            "text": "<!DOCTYPE html><html><head><title>Transporte em Guarulhos - Jávai Logística</title><style>.captcha-form img{float:right}</style></head><body><article><h1>Jávai Logística</h1><p>Transporte em Guarulhos.</p></article><div class=\"g-recaptcha\" data-sitekey=\"k\"></div></body></html>"
           },
           "redirectURL": "",
           "headersSize": -1,
-          "bodySize": 298
+          "bodySize": 281
         }
       }
     ]

--- a/src/providers.json
+++ b/src/providers.json
@@ -501,7 +501,7 @@
           "technique": "captcha",
           "rules": [
             {
-              "regex": "^(?=[\\s\\S]*\\bid=[\"']captcha-form[\"'])(?=[\\s\\S]*g-recaptcha)",
+              "regex": "^(?=[\\s\\S]*\\sid=[\"']captcha-form[\"'])(?=[\\s\\S]*g-recaptcha)",
               "flags": "i"
             }
           ]

--- a/src/providers.json
+++ b/src/providers.json
@@ -352,6 +352,7 @@
         {
           "type": "html",
           "technique": "javascript",
+          "statusCodes": [403, 429, 503],
           "rules": [
             {
               "contains": "CheqSdk"
@@ -500,7 +501,7 @@
           "technique": "captcha",
           "rules": [
             {
-              "regex": "^(?=[\\s\\S]*captcha-form)(?=[\\s\\S]*g-recaptcha)",
+              "regex": "^(?=[\\s\\S]*\\bid=[\"']captcha-form[\"'])(?=[\\s\\S]*g-recaptcha)",
               "flags": "i"
             }
           ]
@@ -564,7 +565,7 @@
           "technique": "captcha",
           "rules": [
             {
-              "regex": "^(?=[\\s\\S]*\\bh-captcha(?!-response))(?=[\\s\\S]*(?:Verify you are (?:a )?human|Attention Required|Please verify))",
+              "regex": "^(?=[\\s\\S]*\\bh-captcha(?!-response))(?=[\\s\\S]*(?:Verify you are (?:a )?human|Attention Required))",
               "flags": "i"
             }
           ]

--- a/test/index.js
+++ b/test/index.js
@@ -386,18 +386,26 @@ test('reblaze (no false positive for bare mention)', t => {
   t.is(result.detected, false)
 })
 
-test('cheq (html CheqSdk)', t => {
+test('cheq (html CheqSdk on a blocking status)', t => {
   const html = '<script>CheqSdk.init();</script>'
-  const result = isAntibot({ html })
+  const result = isAntibot({ html, statusCode: 403 })
   t.is(result.detected, true)
   t.is(result.provider, 'cheq')
 })
 
-test('cheq (html cheqzone.com)', t => {
+test('cheq (html cheqzone.com on a blocking status)', t => {
   const html = '<script src="https://ob.cheqzone.com/script.js"></script>'
-  const result = isAntibot({ html })
+  const result = isAntibot({ html, statusCode: 403 })
   t.is(result.detected, true)
   t.is(result.provider, 'cheq')
+})
+
+test('cheq (SDK preconnect on a 200 content page is not a block)', t => {
+  const html =
+    '<title>FlashArray | Everpure</title><article>Unified block storage</article><link rel="preconnect" href="//obs.cheqzone.com"/>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
 })
 
 test('cheq (url cheqzone.com)', t => {
@@ -589,6 +597,14 @@ test('recaptcha (Google unusual-traffic interstitial on a 200)', t => {
   t.is(result.provider, 'recaptcha')
 })
 
+test('recaptcha (CSS .captcha-form + widget on a 200 page is not a block)', t => {
+  const html =
+    '<title>Transporte em Guarulhos</title><style>.captcha-form img{float:right}</style><article>Jávai Logística</article><div class="g-recaptcha" data-sitekey="k"></div>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
+})
+
 test('hcaptcha (url)', t => {
   const url = 'https://hcaptcha.com/captcha/v1'
   const result = isAntibot({ url })
@@ -638,6 +654,14 @@ test('hcaptcha (Verify you are human interstitial on a 200)', t => {
   const result = isAntibot({ html, statusCode: 200 })
   t.is(result.detected, true)
   t.is(result.provider, 'hcaptcha')
+})
+
+test('hcaptcha (Please verify your email + widget on a 200 page is not a block)', t => {
+  const html =
+    '<title>33 DIY Bag Charm Ideas</title><article>real post</article><div class="h-captcha" data-sitekey="k"></div><script>const copy="Please verify your email address"</script>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
 })
 
 test('hcaptcha (no false positive for Shopify h-captcha-response field)', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -597,6 +597,14 @@ test('recaptcha (Google unusual-traffic interstitial on a 200)', t => {
   t.is(result.provider, 'recaptcha')
 })
 
+test('recaptcha (data-id=captcha-form + widget on a 200 page is not a block)', t => {
+  const html =
+    '<article>real content</article><div data-id="captcha-form" class="g-recaptcha" data-sitekey="k"></div>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
+})
+
 test('recaptcha (CSS .captcha-form + widget on a 200 page is not a block)', t => {
   const html =
     '<title>Transporte em Guarulhos</title><style>.captcha-form img{float:right}</style><article>Jávai Logística</article><div class="g-recaptcha" data-sitekey="k"></div>'


### PR DESCRIPTION
## Summary
- CHEQ `obs.cheqzone.com` preconnect, a CSS `.captcha-form` + reCAPTCHA widget, and an hCaptcha widget next to “Please verify your email” were flagged as challenges on 200 content pages (prod: purestorage.com, dimiexpress.com.br, payhip.com).
- Gate CHEQ HTML on 403/429/503 (their middleware 403s; URL rules still catch cheqzone.com / cheq.ai redirects). Require `id="captcha-form"` for the Google unusual-traffic interstitial. Drop the loose “Please verify” hCaptcha phrase.
- Replay on the captured 200s: 60 units → 25 per request (stop at the first good 200). No fallthrough to another provider.

## Test plan
- [x] `ava test/index.js test/providers.js` (181 passed)
- [x] Re-run `is-antibot` on the captured Pure Storage / Payhip / Dimi Express HTML → `detected: false`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection accuracy for Cheq, reCAPTCHA, and hCaptcha integrations.
  - Reduced false positives on normal content pages that include CAPTCHA-related widgets, styles, or verification messages.
  - Cheq detections now require an applicable blocking response status.
  - Refined matching for reCAPTCHA and hCaptcha page markers.

- **Tests**
  - Expanded coverage for successful, failed, and false-positive detection scenarios across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->