### PR TITLE
fix: ignore Akamai sensor telemetry on content pages

### DIFF
--- a/providers/akamai/failed.json
+++ b/providers/akamai/failed.json
@@ -1,0 +1,68 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "microlink-api",
+      "version": "1.0.0"
+    },
+    "pages": [
+      {
+        "id": "page_1",
+        "title": "Shrine of Remembrance",
+        "startedDateTime": "2026-08-31T06:30:00.000Z",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": 100
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2026-08-31T06:30:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
+        "connection": "443",
+        "request": {
+          "method": "GET",
+          "url": "https://shrine.us2.list-manage.com/subscribe?u=24882855c0ac8b7832a1c3b44&id=ed43b6a37b",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "host",
+              "value": "shrine.us2.list-manage.com"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "set-cookie",
+              "value": "_abck=abc123~0~; Domain=.list-manage.com; Path=/; Secure"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 318,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html><head><title>Shrine of Remembrance</title></head><body><script>bmak.sensor_data = \"test\";</script></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 318
+        }
+      }
+    ]
+  }
+}

--- a/providers/akamai/success.json
+++ b/providers/akamai/success.json
@@ -1,0 +1,68 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "microlink-api",
+      "version": "1.0.0"
+    },
+    "pages": [
+      {
+        "id": "page_1",
+        "title": "Shrine of Remembrance",
+        "startedDateTime": "2026-08-31T06:30:00.000Z",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": 100
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2026-08-31T06:30:00.000Z",
+        "time": 100,
+        "serverIPAddress": "",
+        "connection": "443",
+        "request": {
+          "method": "GET",
+          "url": "https://shrine.us2.list-manage.com/subscribe?u=24882855c0ac8b7832a1c3b44&id=ed43b6a37b",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "host",
+              "value": "shrine.us2.list-manage.com"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "http/1.1",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "set-cookie",
+              "value": "_abck=abc123~0~; Domain=.list-manage.com; Path=/; Secure"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 412,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html><head><title>Shrine of Remembrance</title></head><body><form><label>Email</label><input type=\"email\" name=\"MERGE0\"><input type=\"submit\" value=\"Subscribe\"></form><script>else if (window.bmak) { window.bmak.form_submit(); }</script></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 412
+        }
+      }
+    ]
+  }
+}

--- a/src/providers.json
+++ b/src/providers.json
@@ -76,6 +76,7 @@
         {
           "type": "cookies",
           "technique": "cookie",
+          "statusCodes": [403, 429, 503],
           "rules": [
             {
               "cookie": "_abck="
@@ -87,7 +88,7 @@
           "technique": "javascript",
           "rules": [
             {
-              "contains": "bmak."
+              "contains": "bmak.sensor_data"
             }
           ]
         }

--- a/test/index.js
+++ b/test/index.js
@@ -75,18 +75,35 @@ test('akamai (akamai-grn header alone is not antibot)', t => {
   t.is(result.detection, null)
 })
 
-test('akamai (_abck set-cookie)', t => {
+test('akamai (_abck set-cookie on a blocking status)', t => {
   const headers = { 'set-cookie': '_abck=abc123~0~; path=/' }
-  const result = isAntibot({ headers })
+  const result = isAntibot({ headers, statusCode: 403 })
   t.is(result.detected, true)
   t.is(result.provider, 'akamai')
 })
 
-test('akamai (bmak in html)', t => {
+test('akamai (_abck set-cookie on a content page is not enough)', t => {
+  const headers = { 'set-cookie': '_abck=abc123~0~; path=/' }
+  const html =
+    '<html><head><title>Shrine of Remembrance</title></head><body><form><input type="email" name="MERGE0"><input type="submit" value="Subscribe"></form></body></html>'
+  const result = isAntibot({ headers, html, statusCode: 200 })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
+})
+
+test('akamai (bmak.sensor_data in html)', t => {
   const html = '<script>bmak.sensor_data = "test";</script>'
   const result = isAntibot({ html })
   t.is(result.detected, true)
   t.is(result.provider, 'akamai')
+})
+
+test('akamai (bmak.form_submit telemetry on a content page is not a challenge)', t => {
+  const html =
+    '<html><head><title>Shrine of Remembrance</title></head><body><form><input type="email"><input type="submit" value="Subscribe"></form><script>else if (window.bmak) { window.bmak.form_submit(); }</script></body></html>'
+  const result = isAntibot({ html, statusCode: 200 })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
 })
 
 test('akamai (no antibot)', t => {


### PR DESCRIPTION
## Summary
- Mailchimp subscribe forms (`list-manage.com`) were flagged as Akamai because they call `window.bmak.form_submit()` and set `_abck` on a 200. Production climbed all four proxy hops and never resolved.
- Require `bmak.sensor_data` for the HTML rule (the existing unit test already used that signature). Gate `_abck` on 403/429/503, same shape as DataDome.
- Replay on the captured 200: detected `akamai` → `false`. No fallthrough to reCAPTCHA. 60 units → 1 per request.

## Test plan
- [x] `ava test/index.js test/providers.js` (184 passed)
- [x] Re-run `is-antibot` on the captured Shrine/Mailchimp HTML → `detected: false`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Akamai challenge detection to distinguish blocked responses from successful pages.
  - Avoided incorrectly flagging normal pages containing unrelated Akamai telemetry.
  - Refined detection for challenge-specific content and response status codes.

- **Tests**
  - Added coverage for blocked and successful Akamai responses, including representative browser-session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->