### PR TITLE
fix: ignore PerimeterX session cookie on content pages

### DIFF
--- a/providers/perimeterx/failed.json
+++ b/providers/perimeterx/failed.json
@@ -46,6 +46,14 @@
             {
               "name": "content-type",
               "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "set-cookie",
+              "value": "_px3=abc123; Path=/; Secure"
+            },
+            {
+              "name": "set-cookie",
+              "value": "_pxhd=def456; Path=/; Secure"
             }
           ],
           "cookies": [],

--- a/providers/perimeterx/success.json
+++ b/providers/perimeterx/success.json
@@ -46,6 +46,14 @@
             {
               "name": "content-type",
               "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "set-cookie",
+              "value": "_px3=abc123; Path=/; Secure"
+            },
+            {
+              "name": "set-cookie",
+              "value": "_pxhd=def456; Path=/; Secure"
             }
           ],
           "cookies": [],

--- a/src/providers.json
+++ b/src/providers.json
@@ -183,6 +183,7 @@
         {
           "type": "cookies",
           "technique": "cookie",
+          "statusCodes": [403, 429, 503],
           "rules": [
             {
               "cookie": "_px3="

--- a/test/index.js
+++ b/test/index.js
@@ -222,18 +222,20 @@ test('perimeterx (walmart /blocked url)', t => {
   t.is(result.detection, 'url')
 })
 
-test('perimeterx (_px3 set-cookie)', t => {
+test('perimeterx (_px3 set-cookie on a blocking status)', t => {
   const headers = { 'set-cookie': '_px3=abc123; path=/' }
-  const result = isAntibot({ headers })
+  const result = isAntibot({ headers, statusCode: 403 })
   t.is(result.detected, true)
   t.is(result.provider, 'perimeterx')
 })
 
-test('perimeterx (_pxhd set-cookie)', t => {
+test('perimeterx (_pxhd set-cookie on a content page is not enough)', t => {
   const headers = { 'set-cookie': '_pxhd=abc123; path=/' }
-  const result = isAntibot({ headers })
-  t.is(result.detected, true)
-  t.is(result.provider, 'perimeterx')
+  const html =
+    '<html><head><title>A Purple Evening event returns for Ravens female fans - WBAL</title></head><body><article><p>A Purple Evening event returns for Ravens female fans.</p></article></body></html>'
+  const result = isAntibot({ headers, html, statusCode: 200 })
+  t.is(result.detected, false)
+  t.is(result.provider, null)
 })
 
 test('shapesecurity (header)', t => {


### PR DESCRIPTION
## Summary
- `_px3` / `_pxhd` are session cookies PerimeterX sets on every response it fronts, including 200 articles. On `microlink-api@3.56.0` over the last 5 days, production flagged WBAL, Bloomberg, Skyscanner, and NewsNation on those cookies (`technique=cookie statusCode=200`) and climbed a ladder that already had the article.
- Cookie detection is now gated on `403/429/503`, same as DataDome (`#71`). Real PX blocks stay: `Robot or human` / `px-captcha` / `_pxAction` HTML, `x-px-authorization`, and Walmart `/blocked?`.
- Both `providers/perimeterx/{success,failed}.json` now carry `_px3`/`_pxhd` on the same Walmart URL at 200; they differ only in the challenge HTML so the pair proves the cookie is not the discriminator.

Replay: WBAL article HTML + `_pxhd` + 200 was `detected: true` (cookies) and is now `detected: false`. Challenge HTML + the same cookies stays `detected: true` (html).

A merged PR is not a deployed fix. This needs an npm release of `is-antibot` **and** a dep bump on microlink-api.

## Test plan
- [x] `pnpm test` (216 passing)
- [x] Article HTML + `_pxhd=` cookie + 200 → `detected: false` (was `true` / cookies)
- [x] Article HTML + `_px3=` cookie + 403 → `detected: true` (cookies)
- [x] `Robot or human` / `px-captcha` interstitial + 200 → `detected: true` (html)
- [ ] After npm publish, bump `is-antibot` on microlink-api


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PerimeterX detection by limiting challenge identification to blocking HTTP responses.
  * Prevented false positives when PerimeterX cookies appear on successfully served content pages.
  * Added coverage for relevant PerimeterX response statuses and cookie scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->